### PR TITLE
Add new BLEStringCharacateristic type

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,6 +28,7 @@ BLELongCharacteristic	KEYWORD1
 BLEUnsignedLongCharacteristic	KEYWORD1
 BLEFloatCharacteristic	KEYWORD1
 BLEDoubleCharacteristic	KEYWORD1
+BLEStringCharacteristic	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/src/BLEStringCharacteristic.cpp
+++ b/src/BLEStringCharacteristic.cpp
@@ -17,12 +17,29 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _ARDUINO_BLE_H_
-#define _ARDUINO_BLE_H_
-
-#include "local/BLELocalDevice.h"
-#include "BLEProperty.h"
 #include "BLEStringCharacteristic.h"
-#include "BLETypedCharacteristics.h"
 
-#endif
+BLEStringCharacteristic::BLEStringCharacteristic(const char* uuid, unsigned char properties, int valueSize) :
+  BLECharacteristic(uuid, properties, valueSize)
+{
+}
+
+int BLEStringCharacteristic::writeValue(const String& value)
+{
+  return BLECharacteristic::writeValue(value.c_str());
+}
+
+String BLEStringCharacteristic::value(void)
+{
+  String str;
+  int length = BLECharacteristic::valueLength();
+  const uint8_t* val = BLECharacteristic::value();
+
+  str.reserve(length);
+
+  for (int i = 0; i < length; i++) {
+    str += (char)val[i];
+  }
+
+  return str;
+}

--- a/src/BLEStringCharacteristic.h
+++ b/src/BLEStringCharacteristic.h
@@ -17,12 +17,23 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _ARDUINO_BLE_H_
-#define _ARDUINO_BLE_H_
+#ifndef _BLE_STRING_CHARACTERISTIC_H_
+#define _BLE_STRING_CHARACTERISTIC_H_
 
-#include "local/BLELocalDevice.h"
-#include "BLEProperty.h"
-#include "BLEStringCharacteristic.h"
-#include "BLETypedCharacteristics.h"
+#include <Arduino.h>
+
+#include "BLECharacteristic.h"
+
+class BLEStringCharacteristic : public BLECharacteristic
+{
+public:
+  BLEStringCharacteristic(const char* uuid, unsigned char properties, int valueSize);
+
+  int writeValue(const String& value);
+  int setValue(const String& value) { return writeValue(value); }
+  String value(void);
+
+private:
+};
 
 #endif


### PR DESCRIPTION
Resolves #4.

Example usage sketch:

```arduino
#include <ArduinoBLE.h>

BLEService stringService("19B10000-0001-537E-4F6C-D104768A1214"); // BLE String Service
BLEStringCharacteristic stringCharacteristic("19B10001-0001-537E-4F6C-D104768A1214", BLERead | BLEWrite, 512);

void setup() {
  Serial.begin(9600);
  while (!Serial);

  // begin initialization
  if (!BLE.begin()) {
    Serial.println("starting BLE failed!");

    while (1);
  }

  // set advertised local name and service UUID:
  BLE.setLocalName("String");
  BLE.setAdvertisedService(stringService);

  // add the characteristic to the service
  stringService.addCharacteristic(stringCharacteristic);

  // add service
  BLE.addService(stringService);

  // set the initial value for the characeristic:
  stringCharacteristic.writeValue("hello");

  // start advertising
  BLE.advertise();

  Serial.println("BLE String Peripheral");
}

void loop() {
  // listen for BLE peripherals to connect:
  BLEDevice central = BLE.central();

  // if a central is connected to peripheral:
  if (central) {
    Serial.print("Connected to central: ");
    // print the central's MAC address:
    Serial.println(central.address());

    // while the central is still connected to peripheral:
    while (central.connected()) {
      if (stringCharacteristic.written()) {
        Serial.println("stringCharacteristic written, new value = ");

        String value = stringCharacteristic.value();

        Serial.println(value);
      }
    }

    // when the central disconnects, print it out:
    Serial.print(F("Disconnected from central: "));
    Serial.println(central.address());
  }
}
```