### PR TITLE
Characteristic value lengths can be up to 512 bytes, uint8_t should not be used to store the length

### DIFF
--- a/src/local/BLELocalCharacteristic.h
+++ b/src/local/BLELocalCharacteristic.h
@@ -76,7 +76,7 @@ private:
   uint8_t  _properties;
   int      _valueSize;
   uint8_t* _value;
-  uint8_t  _valueLength;
+  uint16_t  _valueLength;
   bool _fixedLength;
 
   uint16_t _handle;


### PR DESCRIPTION
cc/ @8bitkick