### PR TITLE
cordio: lower power polling with timeout

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -103,8 +103,7 @@ extern "C" void wsf_mbed_ble_signal_event(void)
 }
 #endif //CORDIO_ZERO_COPY_HCI
 
-#undef WSF_MS_PER_TICK
-#define WSF_MS_PER_TICK 10
+#define CORDIO_TRANSPORT_WSF_MS_PER_TICK 10
 
 static void bleLoop()
 {
@@ -117,7 +116,7 @@ static void bleLoop()
         timer.reset();
 
         uint64_t last_update_ms = (last_update_us / 1000);
-        wsfTimerTicks_t wsf_ticks = (last_update_ms / WSF_MS_PER_TICK);
+        wsfTimerTicks_t wsf_ticks = (last_update_ms / CORDIO_TRANSPORT_WSF_MS_PER_TICK);
 
         if (wsf_ticks > 0) {
             WsfTimerUpdate(wsf_ticks);
@@ -138,9 +137,9 @@ static void bleLoop()
         uint64_t time_spent = (uint64_t) timer.read_high_resolution_us();
 
         /* don't bother sleeping if we're already past tick */
-        if (sleep && (WSF_MS_PER_TICK * 1000 > time_spent)) {
+        if (sleep && (CORDIO_TRANSPORT_WSF_MS_PER_TICK * 1000 > time_spent)) {
             /* sleep to maintain constant tick rate */
-            uint64_t wait_time_us = WSF_MS_PER_TICK * 1000 - time_spent;
+            uint64_t wait_time_us = CORDIO_TRANSPORT_WSF_MS_PER_TICK * 1000 - time_spent;
             uint64_t wait_time_ms = wait_time_us / 1000;
 
             wait_time_us = wait_time_us % 1000;


### PR DESCRIPTION
I've been testing this with the `Examples -> Peripheral -> LEDCallback` example, with two changes:

1) Removing: `while (!Serial);` from `setup()`
2) Changing `BLE.poll();` in `loop()` to `BLE.poll(60000);`

Unfortunately, in my brief testing it doesn't seem to be lower power (using a USB supply input).

@facchinm any thoughts on this?