### PR TITLE
Handle ACL RX packet fragementation via buffer

### DIFF
--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -92,6 +92,8 @@ private:
 
   uint8_t _maxPkt;
   uint8_t _pendingPkt;
+
+  uint8_t _aclPktBuffer[255];
 };
 
 extern HCIClass HCI;


### PR DESCRIPTION
@tigoe this should address the issue you were seeing with two Arduino boards (central + peripheral), when one board had more than one 128-bit UUID characteristic per service.

The root cause is the Bluetooth HCI link controller work fragment incoming ACL packets, so I've added an internal buffer to handle this scenario.