### PR TITLE
Cordio: prevent crashes if BLE.begin() is not called

### DIFF
--- a/src/utility/HCICordioTransport.h
+++ b/src/utility/HCICordioTransport.h
@@ -47,6 +47,7 @@ private:
   void handleRxData(uint8_t* data, uint8_t len);
 
 private:
+  bool _begun;
   RingBufferN<256> _rxBuf;
 };
 


### PR DESCRIPTION
@8bitkick, found that not calling `BLE.begin()` before `BLE.advertise()` made things crash on the Arduino Nano 33 BLE.

This change makes things more resilient.