### PR TITLE
Add (optional) company ID argument to BLE.setManufacturerData(....)

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -180,6 +180,11 @@ void BLELocalDevice::setAdvertisedService(const BLEService& service)
   setAdvertisedServiceUuid(service.uuid());
 }
 
+void BLELocalDevice::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
+{
+  GAP.setManufacturerData(manufacturerData, manufacturerDataLength);
+}
+
 void BLELocalDevice::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
   GAP.setManufacturerData(companyId, manufacturerData, manufacturerDataLength);

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -180,9 +180,9 @@ void BLELocalDevice::setAdvertisedService(const BLEService& service)
   setAdvertisedServiceUuid(service.uuid());
 }
 
-void BLELocalDevice::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
+void BLELocalDevice::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
-  GAP.setManufacturerData(manufacturerData, manufacturerDataLength);
+  GAP.setManufacturerData(companyId, manufacturerData, manufacturerDataLength);
 }
 
 void BLELocalDevice::setLocalName(const char *localName)

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -43,6 +43,7 @@ public:
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
   void setAdvertisedService(const BLEService& service);
+  void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
   void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -43,7 +43,7 @@ public:
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
   void setAdvertisedService(const BLEService& service);
-  void setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength);
+  void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 
   void setDeviceName(const char* deviceName);

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -43,7 +43,7 @@ public:
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
   void setAdvertisedService(const BLEService& service);
-  void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
+  void setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 
   void setDeviceName(const char* deviceName);

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -48,7 +48,7 @@ void GAPClass::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
   _advertisedServiceUuid = advertisedServiceUuid;
 }
 
-void GAPClass::setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength)
+void GAPClass::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
   uint8_t tmpManufacturerData[manufacturerDataLength + 2];
   tmpManufacturerData[0] = companyId & 0xff;

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -48,9 +48,13 @@ void GAPClass::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
   _advertisedServiceUuid = advertisedServiceUuid;
 }
 
-void GAPClass::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
+void GAPClass::setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength)
 {
-  _manufacturerData = manufacturerData;
+  uint8_t tmpManufacturerData[manufacturerDataLength + 2];
+  tmpManufacturerData[0] = companyId & 0xff;
+  tmpManufacturerData[1] = companyId >> 8;
+  memcpy(&tmpManufacturerData[2], manufacturerData, manufacturerDataLength);
+  _manufacturerData = tmpManufacturerData;
   _manufacturerDataLength = manufacturerDataLength;
 }
 

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -55,7 +55,7 @@ void GAPClass::setManufacturerData(const uint16_t companyId,const uint8_t manufa
   tmpManufacturerData[1] = companyId >> 8;
   memcpy(&tmpManufacturerData[2], manufacturerData, manufacturerDataLength);
   _manufacturerData = tmpManufacturerData;
-  _manufacturerDataLength = manufacturerDataLength;
+  _manufacturerDataLength = manufacturerDataLength + 2;
 }
 
 void GAPClass::setLocalName(const char *localName)

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -48,14 +48,19 @@ void GAPClass::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
   _advertisedServiceUuid = advertisedServiceUuid;
 }
 
+void GAPClass::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
+{
+  _manufacturerData = manufacturerData;
+  _manufacturerDataLength = manufacturerDataLength;
+}
+
 void GAPClass::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
   uint8_t tmpManufacturerData[manufacturerDataLength + 2];
   tmpManufacturerData[0] = companyId & 0xff;
   tmpManufacturerData[1] = companyId >> 8;
   memcpy(&tmpManufacturerData[2], manufacturerData, manufacturerDataLength);
-  _manufacturerData = tmpManufacturerData;
-  _manufacturerDataLength = manufacturerDataLength + 2;
+  this->setManufacturerData(tmpManufacturerData, manufacturerDataLength + 2);
 }
 
 void GAPClass::setLocalName(const char *localName)

--- a/src/utility/GAP.h
+++ b/src/utility/GAP.h
@@ -30,6 +30,7 @@ public:
   virtual ~GAPClass();
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
+  void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
   void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 

--- a/src/utility/GAP.h
+++ b/src/utility/GAP.h
@@ -30,7 +30,7 @@ public:
   virtual ~GAPClass();
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
-  void setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength);
+  void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 
   bool advertising();

--- a/src/utility/GAP.h
+++ b/src/utility/GAP.h
@@ -30,7 +30,7 @@ public:
   virtual ~GAPClass();
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
-  void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
+  void setManufacturerData(const uint16_t companyId,const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
 
   bool advertising();


### PR DESCRIPTION
##  issue
ArduinoBLE referense sample code
```
  byte data[5] = { 0x01, 0x02, 0x03, 0x04, 0x05};
  BLE.setManufacturerData(data, 5);
```
Result of code execution
0x0201 -> companyId
0x03, 0x04, 0x05 -> manufacturerData

I think it ’s very confusing.

## change
BLE.setManufacturerData(uint8_ uint8_t manufacturerData[], int manufacturerDataLength)
↓
BLE.setManufacturerData(**const uint16_t companyId**, const uint8_t manufacturerData[], int manufacturerDataLength)

## use
```
  uint8_t data[5] = { 0x01, 0x02, 0x03, 0x04, 0x05};
  BLE.setManufacturerData(0x1234, data, 5);
```
0x1234 -> companyId
0x01, 0x02, 0x03, 0x04, 0x05 -> manufacturerData
