### PR TITLE
Fix BLECharacteristic::readValue(...) triggering a read request after a notification/indication was received

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -170,10 +170,9 @@ int BLECharacteristic::readValue(uint8_t value[], int length)
   }
 
   if (_remote) {
-    // trigger a read if the value hasn't been updated via
-    // indication or notification, and the characteristic is
-    // readable
-    if (!valueUpdated() && canRead()) {
+    // trigger a read if the updated value (notification/indication)
+    // has already been read and the characteristic is readable
+    if (_remote->updatedValueRead() && canRead()) {
       if (!read()) {
         // read failed
         return 0;

--- a/src/remote/BLERemoteCharacteristic.cpp
+++ b/src/remote/BLERemoteCharacteristic.cpp
@@ -33,6 +33,7 @@ BLERemoteCharacteristic::BLERemoteCharacteristic(const uint8_t uuid[], uint8_t u
   _value(NULL),
   _valueLength(0),
   _valueUpdated(false),
+  _updatedValueRead(true),
   _valueUpdatedEventHandler(NULL)
 {
 }
@@ -148,6 +149,15 @@ bool BLERemoteCharacteristic::valueUpdated()
   return result;
 }
 
+bool BLERemoteCharacteristic::updatedValueRead()
+{
+  bool result = _updatedValueRead;
+
+  _updatedValueRead = true;
+
+  return result;
+}
+
 bool BLERemoteCharacteristic::read()
 {
   if (!ATT.connected(_connectionHandle)) {
@@ -177,7 +187,6 @@ bool BLERemoteCharacteristic::read()
     return false;
   }
 
-  _valueUpdated = true;
   memcpy(_value, &resp[1], _valueLength); 
 
   return true;
@@ -245,6 +254,7 @@ void BLERemoteCharacteristic::writeValue(BLEDevice device, const uint8_t value[]
   }
 
   _valueUpdated = true;
+  _updatedValueRead = false;
   memcpy(_value, value, _valueLength);
 
   if (_valueUpdatedEventHandler) {

--- a/src/remote/BLERemoteCharacteristic.h
+++ b/src/remote/BLERemoteCharacteristic.h
@@ -42,6 +42,7 @@ public:
   int writeValue(const char* value);
 
   bool valueUpdated();
+  bool updatedValueRead();
 
   bool read();
   bool writeCccd(uint16_t value);
@@ -71,6 +72,7 @@ private:
   int _valueLength;
 
   bool _valueUpdated;
+  bool _updatedValueRead;
 
   BLELinkedList<BLERemoteDescriptor*> _descriptors;
 


### PR DESCRIPTION
Observed by @tigoe, if a notification was received, and the characteristic was readable an unnecessary read request is sent (and value updated would be reset to true as well).

These changes correct this behaviour.