### PR TITLE
[DO NOT MERGE] Add Github Actions workflow with official arduino-cli action to build library examples 

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,50 @@
+name: Build Library Examples
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fqbn: [
+          "arduino:samd:mkrwifi1010",
+          "arduino:samd:nano_33_iot",
+          "arduino:megaavr:uno2018:mode=on",
+          "arduino:mbed:nano33ble"
+        ]
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup arduino-cli
+        uses: arduino/actions/setup-arduino-cli@master
+
+      - name: Export FQBN and BOARD
+        run: |
+          FQBN=${{ matrix.fqbn }}
+          CORE=`echo "$FQBN" | cut -d':' -f1,2`
+          echo ::set-env name=FQBN::"$FQBN"
+          echo ::set-env name=CORE::"$CORE"
+
+      - name: Install Core
+        run: |
+          set -x
+          arduino-cli core update-index
+          arduino-cli core install $CORE
+
+      - name: Symlink Library
+        run: |
+          set -x
+          mkdir -p $HOME/Arduino/libraries
+          ln -s $PWD $HOME/Arduino/libraries/.
+
+      - name: Compile Examples
+        run: |
+          set -x
+          EXAMPLES=`find examples/ -name *.ino | xargs`
+          for EXAMPLE in $EXAMPLES; do
+            echo Building example $EXAMPLE
+            arduino-cli compile --verbose --warnings all --fqbn $FQBN $EXAMPLE
+          done || exit 1

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Compile Examples
         run: |
           set -x
-          EXAMPLES=`find examples/ -name *.ino | xargs`
+          EXAMPLES=`find examples/ -name '*.ino' | xargs dirname | uniq`
           for EXAMPLE in $EXAMPLES; do
             echo Building example $EXAMPLE
             arduino-cli compile --verbose --warnings all --fqbn $FQBN $EXAMPLE


### PR DESCRIPTION
This variant  of #31 replaces: https://github.com/arduino-libraries/ArduinoBLE/blob/master/.travis.yml and and uses the official arduino-cli Github action (https://github.com/arduino/actions/tree/master/setup-arduino-cli)