### PR TITLE
Cordio: BLE thread loop fixes

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -103,8 +103,6 @@ extern "C" void wsf_mbed_ble_signal_event(void)
 }
 #endif //CORDIO_ZERO_COPY_HCI
 
-#define CORDIO_TRANSPORT_WSF_MS_PER_TICK 10
-
 static void bleLoop()
 {
 #if CORDIO_ZERO_COPY_HCI
@@ -118,7 +116,7 @@ static void bleLoop()
         timer.reset();
 
         uint64_t last_update_ms = (last_update_us / 1000);
-        wsfTimerTicks_t wsf_ticks = (last_update_ms / CORDIO_TRANSPORT_WSF_MS_PER_TICK);
+        wsfTimerTicks_t wsf_ticks = (last_update_ms / WSF_MS_PER_TICK);
 
         if (wsf_ticks > 0) {
             WsfTimerUpdate(wsf_ticks);
@@ -139,9 +137,9 @@ static void bleLoop()
         uint64_t time_spent = (uint64_t) timer.read_high_resolution_us();
 
         /* don't bother sleeping if we're already past tick */
-        if (sleep && (CORDIO_TRANSPORT_WSF_MS_PER_TICK * 1000 > time_spent)) {
+        if (sleep && (WSF_MS_PER_TICK * 1000 > time_spent)) {
             /* sleep to maintain constant tick rate */
-            uint64_t wait_time_us = CORDIO_TRANSPORT_WSF_MS_PER_TICK * 1000 - time_spent;
+            uint64_t wait_time_us = WSF_MS_PER_TICK * 1000 - time_spent;
             uint64_t wait_time_ms = wait_time_us / 1000;
 
             wait_time_us = wait_time_us % 1000;

--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -111,6 +111,8 @@ static void bleLoop()
     uint64_t last_update_us = 0;
     mbed::LowPowerTimer timer;
 
+    timer.start();
+
     while (true) {
         last_update_us += (uint64_t) timer.read_high_resolution_us();
         timer.reset();


### PR DESCRIPTION
This resolves #33.

This pull request has two changes:

1) It calls `timer.start()` in the BLE thread loop. Without this, `timer.read_high_resolution_us()` always returns 0.

**Note:** the issue is also present in the mbed sample code the HCI transport was based on: https://github.com/ARMmbed/mbed-os-cordio-hci-passthrough/blob/fix-wsf-msg/main.cpp#L86 (@facchinm should we inform them?)

2) It reverts part of pull request #15. Unfortunately, the `WSF_MS_PER_TICK` needs to match the value mbed was compiled with for the supervision timeout to match: https://github.com/ARMmbed/mbed-os/blob/19e762298f9a020606f7358539bb653be0de8e4f/features/FEATURE_BLE/targets/TARGET_CORDIO_LL/stack/controller/sources/ble/lctr/lctr_main_conn.c#L1168-L1174

@facchinm I think we should measure the power consumption again. Then re-compile mbed if we need to adjust the value.

It's currently set to 1 ms:
- https://github.com/arduino/ArduinoCore-nRF528x-mbedos/blob/a1816cd20de39ffc03a9cfd6b378e7b63b210a89/variants/ARDUINO_NANO33BLE/mbed_config.h#L336

however, the default appears to 10 ms: https://github.com/arduino/ArduinoCore-nRF528x-mbedos/blob/beac74ca3cd9d07363f66cf9cda6b143e4385cd2/cores/arduino/mbed/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/wsf/include/wsf_timer.h#L40