### PR TITLE
Dangling pointer in setManufacturerData

### DIFF
--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -54,7 +54,7 @@ void GAPClass::setManufacturerData(const uint8_t manufacturerData[], int manufac
   _manufacturerDataLength = manufacturerDataLength;
 }
 
-void GAPClass::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
+void GAPClass::setManufacturerData(const uint16_t companyId, const uint8_t &manufacturerData[], int manufacturerDataLength)
 {
   uint8_t tmpManufacturerData[manufacturerDataLength + 2];
   tmpManufacturerData[0] = companyId & 0xff;


### PR DESCRIPTION
This code sets the member _manufacturerData to an array on the stack:
this causes the crash.

SOLUTION:-
Actually, We can pass it by reference or make an array global.

@facchinm #56 issue mention this same 10 days back, no merge request is made by the originator of #56 issue so that is why I have make this request.
Thank you