### PR TITLE
setManufacturerData: allocate tmpManufacturerData in the heap

### DIFF
--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -97,17 +97,17 @@ int GAPClass::advertise()
     BLEUuid uuid(_advertisedServiceUuid);
     int uuidLen = uuid.length();
 
-    advertisingData[3] = 1 + uuidLen;
-    advertisingData[4] = (uuidLen > 2) ? 0x06 : 0x02;
-    memcpy(&advertisingData[5], uuid.data(), uuidLen);
+    advertisingData[advertisingDataLen++] = 1 + uuidLen;
+    advertisingData[advertisingDataLen++] = (uuidLen > 2) ? 0x06 : 0x02;
+    memcpy(&advertisingData[advertisingDataLen], uuid.data(), uuidLen);
 
-    advertisingDataLen += (2 + uuidLen);
+    advertisingDataLen += uuidLen;
   } else if (_manufacturerData && _manufacturerDataLength) {
-    advertisingData[3] = 1 + _manufacturerDataLength;
-    advertisingData[4] = 0xff;
-    memcpy(&advertisingData[5], _manufacturerData, _manufacturerDataLength);
+    advertisingData[advertisingDataLen++] = 1 + _manufacturerDataLength;
+    advertisingData[advertisingDataLen++] = 0xff;
+    memcpy(&advertisingData[advertisingDataLen], _manufacturerData, _manufacturerDataLength);
 
-    advertisingDataLen += (2 + _manufacturerDataLength);
+    advertisingDataLen += _manufacturerDataLength;
   }
 
   if (_serviceData && _serviceDataLength > 0 && advertisingDataLen >= (_serviceDataLength + 4)) {

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -56,7 +56,7 @@ void GAPClass::setManufacturerData(const uint8_t manufacturerData[], int manufac
 
 void GAPClass::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
-  uint8_t tmpManufacturerData[manufacturerDataLength + 2];
+  uint8_t* tmpManufacturerData = (uint8_t*)malloc(manufacturerDataLength + 2);
   tmpManufacturerData[0] = companyId & 0xff;
   tmpManufacturerData[1] = companyId >> 8;
   memcpy(&tmpManufacturerData[2], manufacturerData, manufacturerDataLength);


### PR DESCRIPTION
Fixes https://github.com/arduino-libraries/ArduinoBLE/issues/56
Right now, `setAdvertisedService()` shadows `setManufacturerData()` if called in the sketch (due to the `else if` statement).
Commit e83c3ce prepares for the coexistence but I have to read the specs a bit more before having it enabled.