### PR TITLE
Add callback handling on disconnection to ATTClass::disconnect()

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -481,6 +481,12 @@ bool ATTClass::disconnect()
     }
 
     numDisconnects++;
+    
+    BLEDevice bleDevice(_peers[i].addressType, _peers[i].address);
+
+    if (_eventHandlers[BLEDisconnected]) {
+      _eventHandlers[BLEDisconnected](bleDevice);
+    }
 
     _peers[i].connectionHandle = 0xffff;
     _peers[i].role = 0x00;


### PR DESCRIPTION
Using same method as ATTClass::removeConnection.

Addresses issue #66 