### PR TITLE
Added option to allow writeValue() without response

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -234,6 +234,18 @@ int BLECharacteristic::readValue(int32_t& value)
   return readValue((uint8_t*)&value, sizeof(value));
 }
 
+int BLECharacteristic::writeValue(const uint8_t value[], int length, bool bWithResponse)
+{
+   if (_local) {
+     return _local->writeValue(value, length);
+   }
+
+   if (_remote) {
+     return _remote->writeValue(value, length, bWithResponse);
+   }
+  return 0;
+}
+
 int BLECharacteristic::writeValue(const uint8_t value[], int length)
 {
   if (_local) {
@@ -245,6 +257,11 @@ int BLECharacteristic::writeValue(const uint8_t value[], int length)
   }
 
   return 0;
+}
+
+int BLECharacteristic::writeValue(const void* value, int length, bool bWithResponse)
+{
+  return writeValue((const uint8_t*)value, length, bWithResponse);
 }
 
 int BLECharacteristic::writeValue(const void* value, int length)

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -69,7 +69,9 @@ public:
   int readValue(int32_t& value);
 
   int writeValue(const uint8_t value[], int length);
+  int writeValue(const uint8_t value[], int length, bool bWithResponse);
   int writeValue(const void* value, int length);
+  int writeValue(const void* value, int length, bool bWithResponse);
   int writeValue(const char* value);
   int writeValue(uint8_t value);
   int writeValue(int8_t value);

--- a/src/remote/BLERemoteCharacteristic.h
+++ b/src/remote/BLERemoteCharacteristic.h
@@ -39,6 +39,7 @@ public:
   uint8_t operator[] (int offset) const;
 
   int writeValue(const uint8_t value[], int length);
+  int writeValue(const uint8_t value[], int length, bool bWithResponse);
   int writeValue(const char* value);
 
   bool valueUpdated();


### PR DESCRIPTION
The existing code doesn't allow the writeValue() method to choose writeWithoutResponse when both properties are present. It will use the "with response" option when both properties are present. This lack of choice makes data transfer much slower when you would prefer to send data to a remote device that is not in your control (e.g. one that offers only characteristics with both write and writeWithoutResponse enabled). My patch adds another version of the writeValue() method with a boolean as the last parameter (bool bWithResponse) to allow you to specify false to select writing without a response.