### PR TITLE
Fix service data size check in advertising packets

### DIFF
--- a/examples/Central/Scan/Scan.ino
+++ b/examples/Central/Scan/Scan.ino
@@ -2,7 +2,7 @@
   Scan
 
   This example scans for BLE peripherals and prints out their advertising details:
-  address, local name, adverised service UUID's.
+  address, local name, advertised service UUID's.
 
   The circuit:
   - Arduino MKR WiFi 1010, Arduino Uno WiFi Rev2 board, Arduino Nano 33 IoT,

--- a/examples/Central/ScanCallback/ScanCallback.ino
+++ b/examples/Central/ScanCallback/ScanCallback.ino
@@ -2,7 +2,7 @@
   Scan Callback
 
   This example scans for BLE peripherals and prints out their advertising details:
-  address, local name, adverised service UUIDs. Unlike the Scan example, it uses
+  address, local name, advertised service UUIDs. Unlike the Scan example, it uses
   the callback style APIs and disables filtering so the peripheral discovery is
   reported for every single advertisement it makes.
 

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -110,7 +110,7 @@ int GAPClass::advertise()
     advertisingDataLen += _manufacturerDataLength;
   }
 
-  if (_serviceData && _serviceDataLength > 0 && advertisingDataLen >= (_serviceDataLength + 4)) {
+  if (_serviceData && _serviceDataLength > 0 && (sizeof(advertisingData) - advertisingDataLen) >= (_serviceDataLength + 4)) {
     advertisingData[advertisingDataLen++] = _serviceDataLength + 3;
     advertisingData[advertisingDataLen++] = 0x16;
 
@@ -153,7 +153,7 @@ int GAPClass::advertise()
     return 0;
   }
 
-  _advertising = false;
+  _advertising = true;
 
   return 1;
 }
@@ -240,7 +240,7 @@ BLEDevice GAPClass::available()
         return result;
       } else {
         continue;
-      } 
+      }
     }
   }
 


### PR DESCRIPTION
Addresses issue #85 - Service data isn't added to the advertisting
packet

Updates the GAP's advertise method to check the remaining size of the
buffer, rather than the current place in the buffer.
Also correctly sets the _advertising flag once advertising is complete.