### PR TITLE
PDU rejected due to wrong opcode set in 'Request Opcode In Error'

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -756,7 +756,7 @@ void ATTClass::findByTypeReq(uint16_t connectionHandle, uint16_t mtu, uint8_t dl
   } *findByTypeReq = (FindByTypeReq*)data;
 
   if (dlen < sizeof(FindByTypeReq)) {
-    sendError(connectionHandle, ATT_OP_FIND_BY_TYPE_RESP, findByTypeReq->startHandle, ATT_ECODE_INVALID_PDU);
+    sendError(connectionHandle, ATT_OP_FIND_BY_TYPE_REQ, findByTypeReq->startHandle, ATT_ECODE_INVALID_PDU);
     return;
   }
 
@@ -794,7 +794,7 @@ void ATTClass::findByTypeReq(uint16_t connectionHandle, uint16_t mtu, uint8_t dl
   }
 
   if (responseLength == 1) {
-    sendError(connectionHandle, ATT_OP_FIND_BY_TYPE_RESP, findByTypeReq->startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+    sendError(connectionHandle, ATT_OP_FIND_BY_TYPE_REQ, findByTypeReq->startHandle, ATT_ECODE_ATTR_NOT_FOUND);
   } else {
     HCI.sendAclPkt(connectionHandle, ATT_CID, responseLength, response);
   }


### PR DESCRIPTION
3.4.1.1 of ATT protocol spec suggests that in the ATT_ERROR_RSP, the Request Opcode In Error should be set to the request that generated the error.  In this case it looks like it should actually be  ATT_FIND_BY_TYPE_VALUE_REQ (ATT_OP_READ_BY_GROUP_REQ)