### PR TITLE
Fix discovery of descriptors

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -1561,7 +1561,7 @@ bool ATTClass::discoverDescriptors(uint16_t connectionHandle, BLERemoteDevice* d
 
     for (int j = 0; j < characteristicCount; j++) {
       BLERemoteCharacteristic* characteristic = service->characteristic(j);
-      BLERemoteCharacteristic* nextCharacteristic = (j == (characteristicCount - 1)) ? NULL : service->characteristic(j);
+      BLERemoteCharacteristic* nextCharacteristic = (j == (characteristicCount - 1)) ? NULL : service->characteristic(j + 1);
 
       reqStartHandle = characteristic->valueHandle() + 1;
       reqEndHandle = nextCharacteristic ? nextCharacteristic->valueHandle() : serviceEndHandle;


### PR DESCRIPTION
The 'nextCharacteristic' selection was wrong.
Thus, when using nextCharacteristic for taking the end handle for the request, the end handle of the current characteristic was taken.
This resulted in the following condition to be true: (reqStartHandle > reqEndHandle)
For such reason, in many cases the descriptors were not retrieved. Specifically, all the characteristics of a service, except the last one, will result without descriptors.
This will result in an error where trying to subscribe to a characteristic which has a descriptor before the CCCD one. (for instance the User Description Descriptor)
In case the subscription is made on a characteristic having the CCCD as first descriptor there are no errors, because if no descriptors are found the write request, needed for the subscription, will be made to the char value handle + 1.