### PR TITLE
Implement functions to retrieve multiple connected devices

### DIFF
--- a/src/local/BLELocalCharacteristic.cpp
+++ b/src/local/BLELocalCharacteristic.cpp
@@ -124,7 +124,10 @@ int BLELocalCharacteristic::writeValue(const uint8_t value[], int length)
 
     BLE.setAdvertisedServiceData(serviceUuid, value, length);
   
+  // TO BE REVISIONED
+    // could advertise also if connected
     if (!ATT.connected() && GAP.advertising()) {
+      // if it is already advertising it should stop before requesting advertising again
       BLE.advertise();
     }
   }

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -297,6 +297,41 @@ BLEDevice BLELocalDevice::central()
   return ATT.central();
 }
 
+BLEDevice BLELocalDevice::central(int index)
+{
+  HCI.poll();
+
+  return ATT.central(index);
+}
+
+int BLELocalDevice::centralCount()
+{
+  HCI.poll();
+
+  return ATT.centralCount();
+}
+
+BLEDevice BLELocalDevice::peripheral() 
+{
+  HCI.poll();
+
+  return ATT.peripheral();
+}
+
+BLEDevice BLELocalDevice::peripheral(int index) 
+{
+  HCI.poll();
+
+  return ATT.peripheral(index);
+}
+
+int BLELocalDevice::peripheralCount()
+{
+  HCI.poll();
+
+  return ATT.peripheralCount();
+}
+
 BLEDevice BLELocalDevice::available()
 {
   HCI.poll();

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -67,7 +67,13 @@ public:
   virtual void stopScan();
 
   virtual BLEDevice central();
-  virtual BLEDevice available();
+  virtual BLEDevice available(); 
+  int centralCount();
+  BLEDevice peripheral(); 
+  BLEDevice peripheral(int index); 
+  int peripheralCount();
+  BLEDevice available();
+
 
   virtual void setAdvertisingInterval(uint16_t advertisingInterval);
   virtual void setConnectionInterval(uint16_t minimumConnectionInterval, uint16_t maximumConnectionInterval);

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -67,13 +67,12 @@ public:
   virtual void stopScan();
 
   virtual BLEDevice central();
-  virtual BLEDevice available(); 
-  int centralCount();
-  BLEDevice peripheral(); 
-  BLEDevice peripheral(int index); 
-  int peripheralCount();
-  BLEDevice available();
-
+  virtual BLEDevice central(int index);
+  virtual int centralCount();
+  virtual BLEDevice peripheral(); 
+  virtual BLEDevice peripheral(int index); 
+  virtual int peripheralCount();
+  virtual BLEDevice available();
 
   virtual void setAdvertisingInterval(uint16_t advertisingInterval);
   virtual void setConnectionInterval(uint16_t minimumConnectionInterval, uint16_t maximumConnectionInterval);

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -497,17 +497,76 @@ bool ATTClass::disconnect()
   return (numDisconnects > 0);
 }
 
-BLEDevice ATTClass::central()
+BLEDevice ATTClass::central() 
 {
+  return central(0);
+}
+
+BLEDevice ATTClass::central(int index) 
+{
+  int currentIndex = 0;
   for (int i = 0; i < ATT_MAX_PEERS; i++) {
     if (_peers[i].connectionHandle == 0xffff || _peers[i].role != 0x01) {
       continue;
     }
 
-    return BLEDevice(_peers[i].addressType, _peers[i].address);
+    if (currentIndex == index) {
+      return BLEDevice(_peers[i].addressType, _peers[i].address);
+    }
+    currentIndex++;
   }
 
   return BLEDevice();
+}
+
+int ATTClass::centralCount()
+{
+  int count = 0;
+  for (int i = 0; i < ATT_MAX_PEERS; i++) {
+    if (_peers[i].connectionHandle == 0xffff || _peers[i].role != 0x01) {
+      continue;
+    }
+
+    count++;
+  }
+
+  return count;
+}
+
+BLEDevice ATTClass::peripheral()
+{
+  return peripheral(0);
+}
+
+BLEDevice ATTClass::peripheral(int index)
+{
+  int currentIndex = 0;
+  for (int i = 0; i < ATT_MAX_PEERS; i++) {
+    if (_peers[i].connectionHandle == 0xffff || _peers[i].role != 0x00) {
+      continue;
+    }
+
+    if (currentIndex == index) {
+      return BLEDevice(_peers[i].addressType, _peers[i].address);
+    }
+    currentIndex++;
+  }
+
+  return BLEDevice();
+}
+
+int ATTClass::peripheralCount()
+{
+  int count = 0;
+  for (int i = 0; i < ATT_MAX_PEERS; i++) {
+    if (_peers[i].connectionHandle == 0xffff || _peers[i].role != 0x00) {
+      continue;
+    }
+
+    count++;
+  }
+
+  return count;
 }
 
 bool ATTClass::handleNotify(uint16_t handle, const uint8_t* value, int length)

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -109,8 +109,9 @@ ATTClass::~ATTClass()
 
 bool ATTClass::connect(uint8_t peerBdaddrType, uint8_t peerBdaddr[6])
 {
+  // original supervision timeout "0x00c8" seems to be too short for Nano 33 BLE (2 seconds)
   if (HCI.leCreateConn(0x0060, 0x0030, 0x00, peerBdaddrType, peerBdaddr, 0x00,
-                        0x0006, 0x000c, 0x0000, 0x00c8, 0x0004, 0x0006) != 0) {
+                        0x0006, 0x000c, 0x0000, 1000, 0x0004, 0x0006) != 0) { 
     return false;
   }
 

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -111,7 +111,7 @@ bool ATTClass::connect(uint8_t peerBdaddrType, uint8_t peerBdaddr[6])
 {
   // original supervision timeout "0x00c8" seems to be too short for Nano 33 BLE (2 seconds)
   if (HCI.leCreateConn(0x0060, 0x0030, 0x00, peerBdaddrType, peerBdaddr, 0x00,
-                        0x0006, 0x000c, 0x0000, 1000, 0x0004, 0x0006) != 0) { 
+                        0x001c, 0x0020, 0x0000, 1000, 0x0004, 0x0006) != 0) { 
     return false;
   }
 

--- a/src/utility/ATT.h
+++ b/src/utility/ATT.h
@@ -67,6 +67,11 @@ public:
   virtual bool disconnect();
 
   virtual BLEDevice central();
+  BLEDevice central(int index); 
+  int centralCount();
+  BLEDevice peripheral(); 
+  BLEDevice peripheral(int index); 
+  int peripheralCount();
 
   virtual bool handleNotify(uint16_t handle, const uint8_t* value, int length);
   virtual bool handleInd(uint16_t handle, const uint8_t* value, int length);

--- a/src/utility/ATT.h
+++ b/src/utility/ATT.h
@@ -67,11 +67,11 @@ public:
   virtual bool disconnect();
 
   virtual BLEDevice central();
-  BLEDevice central(int index); 
-  int centralCount();
-  BLEDevice peripheral(); 
-  BLEDevice peripheral(int index); 
-  int peripheralCount();
+  virtual BLEDevice central(int index); 
+  virtual int centralCount();
+  virtual BLEDevice peripheral(); 
+  virtual BLEDevice peripheral(int index); 
+  virtual int peripheralCount();
 
   virtual bool handleNotify(uint16_t handle, const uint8_t* value, int length);
   virtual bool handleInd(uint16_t handle, const uint8_t* value, int length);

--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -84,7 +84,8 @@ void GAPClass::stopAdvertise()
 
 int GAPClass::scan(bool withDuplicates)
 {
-  HCI.leSetScanEnable(false, true);
+  //HCI.leSetScanEnable(false, true);
+  stopScan();
 
   // active scan, 10 ms scan interval (N * 0.625), 10 ms scan window (N * 0.625), public own address type, no filter
   if (HCI.leSetScanParameters(0x01, 0x0010, 0x0010, 0x00, 0x00) != 0) {
@@ -129,7 +130,8 @@ int GAPClass::scanForAddress(String address, bool withDuplicates)
 
 void GAPClass::stopScan()
 {
-  HCI.leSetScanEnable(false, false);
+  //HCI.leSetScanEnable(false, false);
+  HCI.leSetScanEnable(false, true);
 
   _scanning = false;
 

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -620,6 +620,10 @@ void HCIClass::handleEventPkt(uint8_t /*plen*/, uint8_t pdata[])
         uint16_t supervisionTimeout;
         uint8_t masterClockAccuracy;
       } *leConnectionComplete = (EvtLeConnectionComplete*)&pdata[sizeof(HCIEventHdr) + sizeof(LeMetaEventHeader)];
+
+      // CLIENT: 0x01 / PERIPHERAL: 0x00
+      Serial.println("role:");
+      Serial.println(leConnectionComplete->role);
     
       if (leConnectionComplete->status == 0x00) {
         ATT.addConnection(leConnectionComplete->handle,

--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -286,6 +286,8 @@ size_t HCICordioTransportClass::write(const uint8_t* data, size_t length)
 void HCICordioTransportClass::handleRxData(uint8_t* data, uint8_t len)
 {
   if (_rxBuf.availableForStore() < len) {
+    // This drop can cause many problems
+    Serial.println("DROP");
     // drop!
     return;
   }


### PR DESCRIPTION
These functions can be used to loop the connected devices, centrals or peripherals, through an index that can go from 0 to the maximum number of connected devices allowed.
Example:
``` C++
for (int periphIdx = 0; periphIdx < BLE.peripheralCount(); periphIdx++) {
    BLEDevice peripheral = BLE.peripheral(periphIdx);
    if (peripheral) {
    BLECharacteristic batteryLevelChar = peripheral.characteristic("2A19");
        if (!batteryLevelChar) {
            Serial.println("Peripheral does not have battery level characteristic!");
            peripheral.disconnect();
        }
    }
}
```