### PR TITLE
Exposed GAP.setAdvertisedServiceData to BLELocalDevice

### DIFF
--- a/examples/Peripheral/ClimateSensor/ClimateSensor.ino
+++ b/examples/Peripheral/ClimateSensor/ClimateSensor.ino
@@ -1,0 +1,71 @@
+/*
+  Climate Sensor
+
+  This example creates a BLE peripheral which emulates a Xiami Mijia climate
+  sensor.  This device encodes the temperature and humidity into the service
+  data, so BLE apps can detect the current readings without connecting.  For
+  more information see here:
+  https://github.com/mspider65/Xiaomi-Mijia-Bluetooth-Temperature-and-Humidity-Sensor
+
+  The circuit:
+  - Arduino MKR WiFi 1010, Arduino Uno WiFi Rev2 board, Arduino Nano 33 IoT,
+    Arduino Nano 33 BLE, or Arduino Nano 33 BLE Sense board.
+
+  This example code is in the public domain.
+*/
+
+#include <ArduinoBLE.h>
+
+
+void setup() {
+  Serial.begin(9600);    // initialize serial communication
+  while (!Serial);
+
+  pinMode(LED_BUILTIN, OUTPUT); // initialize the built-in LED pin to indicate when a central is connected
+
+  // begin initialization
+  if (!BLE.begin()) {
+    Serial.println("starting BLE failed!");
+
+    while (1);
+  }
+
+  /* Set a local name for the BLE device
+     This name will appear in advertising packets
+     and can be used by remote devices to identify this BLE device
+     The name can be changed but maybe be truncated based on space left in advertisement packet
+  */
+
+  // read all the sensor values if you have something like a HTS sensor
+  float temperature = 28.5; // HTS.readTemperature();
+  float humidity    = 42.0; // HTS.readHumidity();
+
+  // convert the temperatures to a 16-bit byte format
+  uint16_t tempBytes = temperature * 10.0;
+  uint16_t humidityBytes = humidity * 10.0;
+
+  // prepare the service data payload, this emulates a Xiamo Mijia BLE Climate Sensor
+  uint16_t uuid = 0xFE95;
+  uint8_t serviceDataLength = 18;
+  uint8_t serviceData[] = {0x50, 0x20, 0xAA, 0x01, 0x17, 0xEE, 0x7F, 0xB5, 0x91, 0xFB, 0xE8, 0x0D, 0x10, 0x04, tempBytes & 0xFF, tempBytes>>8, humidityBytes & 0xFF, humidityBytes>>8};
+
+  // Set the service data
+  BLE.setAdvertisedServiceData(uuid, serviceData, serviceDataLength);
+
+  /* Start advertising BLE.  It will start continuously transmitting BLE
+     advertising packets and will be visible to remote BLE central devices
+     until it receives a new connection */
+
+  // start advertising
+  BLE.advertise();
+
+  Serial.println("Bluetooth device active and advertising...");
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(500);
+
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(500);
+}

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -193,6 +193,11 @@ void BLELocalDevice::setAdvertisedService(const BLEService& service)
   setAdvertisedServiceUuid(service.uuid());
 }
 
+void BLELocalDevice::setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length)
+{
+  GAP.setAdvertisedServiceData(uuid, data, length);
+}
+
 void BLELocalDevice::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
 {
   GAP.setManufacturerData(manufacturerData, manufacturerDataLength);

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -43,6 +43,7 @@ public:
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
   void setAdvertisedService(const BLEService& service);
+  void setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length);
   void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
   void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);

--- a/src/utility/GAP.h
+++ b/src/utility/GAP.h
@@ -30,6 +30,7 @@ public:
   virtual ~GAPClass();
 
   void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
+  void setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length);
   void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
   void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
   void setLocalName(const char *localName);
@@ -53,7 +54,6 @@ public:
 protected:
   friend class BLELocalCharacteristic;
 
-  void setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length);
 
 protected:
   friend class HCIClass;


### PR DESCRIPTION
This change is intended to allow Service Data to be set from be BLELocalDevice.  The methods required already existed but were **protected**.  I have moved these into the **public** scope and added a method on BLELocalDevice to use them.  

Also included is a short example which emulates a Xiami Mijia climate sensor.  This product encodes the temperature and humidity measurements into the service data, allowing BLE devices to see the current measurements without the need to connect and interrogate it.

Running the sample code on an Arduino Nano 33 BLE Sense with the HTS sensor allows you to plug in real measurements.