### PR TITLE
Add apollo3 core support

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Enables BLE connectivity on the Arduino MKR WiFi 1010, Arduino UNO WiFi
 paragraph=This library supports creating a BLE peripheral and BLE central mode.
 category=Communication
 url=https://www.arduino.cc/en/Reference/ArduinoBLE
-architectures=samd,megaavr,mbed
+architectures=samd,megaavr,mbed,apollo3
 includes=ArduinoBLE.h


### PR DESCRIPTION
Hey all,

We recently added support for this library on our artemis board which have an apollo3 core. No changes needed other than updating architectures list to include these boards.