### PR TITLE
Change allocation of default services and characteristics

### DIFF
--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -28,19 +28,12 @@
 #include "GATT.h"
 
 GATTClass::GATTClass() :
-  _genericAccessService("1800"),
-  _deviceNameCharacteristic("2a00", BLERead, 20),
-  _appearanceCharacteristic("2a01", BLERead, 2),
-  _genericAttributeService("1801"),
-  _servicesChangedCharacteristic("2a05", BLEIndicate, 4)
+  _genericAccessService(NULL),
+  _deviceNameCharacteristic(NULL),
+  _appearanceCharacteristic(NULL),
+  _genericAttributeService(NULL),
+  _servicesChangedCharacteristic(NULL)
 {
-  _genericAccessService.retain();
-  _genericAttributeService.retain();
-
-  _genericAccessService.addCharacteristic(&_deviceNameCharacteristic);
-  _genericAccessService.addCharacteristic(&_appearanceCharacteristic);
-
-  _genericAttributeService.addCharacteristic(&_servicesChangedCharacteristic);
 }
 
 GATTClass::~GATTClass()
@@ -50,13 +43,29 @@ GATTClass::~GATTClass()
 
 void GATTClass::begin()
 {
+  _genericAccessService = new BLELocalService("1800");
+  _deviceNameCharacteristic = new BLELocalCharacteristic("2a00", BLERead, 20);
+  _appearanceCharacteristic = new BLELocalCharacteristic("2a01", BLERead, 2);
+  _genericAttributeService = new BLELocalService("1801");
+  _servicesChangedCharacteristic = new BLELocalCharacteristic("2a05", BLEIndicate, 4);
+
+  _genericAccessService->retain();
+  _deviceNameCharacteristic->retain();
+  _appearanceCharacteristic->retain();
+  _genericAttributeService->retain();
+  _servicesChangedCharacteristic->retain();
+
+  _genericAccessService->addCharacteristic(_deviceNameCharacteristic);
+  _genericAccessService->addCharacteristic(_appearanceCharacteristic);
+  _genericAttributeService->addCharacteristic(_servicesChangedCharacteristic);
+
   setDeviceName("Arduino");
   setAppearance(0x000);
 
   clearAttributes();
 
-  addService(&_genericAccessService);
-  addService(&_genericAttributeService);
+  addService(_genericAccessService);
+  addService(_genericAttributeService);
 }
 
 void GATTClass::end()
@@ -66,12 +75,12 @@ void GATTClass::end()
 
 void GATTClass::setDeviceName(const char* deviceName)
 {
-  _deviceNameCharacteristic.writeValue(deviceName);
+  _deviceNameCharacteristic->writeValue(deviceName);
 }
 
 void GATTClass::setAppearance(uint16_t appearance)
 {
-  _appearanceCharacteristic.writeValue((uint8_t*)&appearance, sizeof(appearance));
+  _appearanceCharacteristic->writeValue((uint8_t*)&appearance, sizeof(appearance));
 }
 
 void GATTClass::addService(BLEService& service)

--- a/src/utility/GATT.h
+++ b/src/utility/GATT.h
@@ -60,11 +60,11 @@ private:
 private:
   BLELinkedList<BLELocalAttribute*> _attributes;
 
-  BLELocalService              _genericAccessService;
-  BLELocalCharacteristic       _deviceNameCharacteristic;
-  BLELocalCharacteristic       _appearanceCharacteristic;
-  BLELocalService              _genericAttributeService;
-  BLELocalCharacteristic       _servicesChangedCharacteristic;
+  BLELocalService*              _genericAccessService;
+  BLELocalCharacteristic*       _deviceNameCharacteristic;
+  BLELocalCharacteristic*       _appearanceCharacteristic;
+  BLELocalService*              _genericAttributeService;
+  BLELocalCharacteristic*       _servicesChangedCharacteristic;
 };
 
 extern GATTClass GATT;


### PR DESCRIPTION
Default local characteristics and services are now allocated in the HEAP.
This change is needed for CI integration. Indeed, if these attributes are allocated in the STACK they cannot be freed by the 'delete' statement actually called by their destructors.
Downside: being allocated in the HEAP, their memory usage will not be counted in the estimated amount of RAM occupied by a resulting program that includes this library.