### PR TITLE
Adjust ATT_MAX_PEERS definition and increase max number of BLE connections for MKR WiFi 1010

### DIFF
--- a/src/utility/ATT.h
+++ b/src/utility/ATT.h
@@ -26,12 +26,12 @@
 
 #define ATT_CID       0x0004
 
-#if defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_PORTENTA_H7_M7)
-#define ATT_MAX_PEERS 7
-#elif DM_CONN_MAX
+#if DM_CONN_MAX
 #define ATT_MAX_PEERS DM_CONN_MAX // Mbed + Cordio
-#else
+#elif __AVR__
 #define ATT_MAX_PEERS 3
+#else
+#define ATT_MAX_PEERS 8
 #endif
 
 class BLERemoteDevice;


### PR DESCRIPTION
This patch will allow to define different ATT_MAX_PEERS according to the used core:
- in platforms that use ArduinoCore-mbed, ATT_MAX_PEERS will be defined by DM_CONN_MAX ([here](https://github.com/arduino/ArduinoCore-mbed/pull/82) set to be equal to 5);
- in platforms that use ArduinoCore-avr (Uno WiFi Rev2), ATT_MAX_PEERS = 3;
- in platforms that use ArduinoCore-samd (MKR WiFi 1010), ATT_MAX_PEERS = 8.