### PR TITLE
Update spell-check action and skip extras/test path

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,11 +1,16 @@
 name: Spell Check
-on: [push, pull_request]
-jobs:
- build:
-   runs-on: ubuntu-latest
 
-   steps:
-     - uses: actions/checkout@v1
-       with:
-         fetch-depth: 1
-     - uses: arduino/actions/libraries/spell-check@master
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: arduino/actions/libraries/spell-check@master
+        with:
+          skip-paths: ./extras/test


### PR DESCRIPTION
After #122, CI unit testing with Catch2 is supported for this library. The spell-check action was failing due to some checks in the catch2 libraries, like in this [example](https://github.com/arduino-libraries/ArduinoBLE/pull/131/checks?check_run_id=1331198955).
This patch will allow to ignore the extras/test folder during the execution of this action and avoid these failures. 