### PR TITLE
API: set advertising param functions return success

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -184,34 +184,34 @@ int BLELocalDevice::rssi()
   return 127;
 }
 
-void BLELocalDevice::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
+bool BLELocalDevice::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
 {
-  _advertisingData.setAdvertisedServiceUuid(advertisedServiceUuid);
+  return _advertisingData.setAdvertisedServiceUuid(advertisedServiceUuid);
 }
 
-void BLELocalDevice::setAdvertisedService(const BLEService& service)
+bool BLELocalDevice::setAdvertisedService(const BLEService& service)
 {
-  setAdvertisedServiceUuid(service.uuid());
+  return setAdvertisedServiceUuid(service.uuid());
 }
 
-void BLELocalDevice::setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length)
+bool BLELocalDevice::setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length)
 {
-  _advertisingData.setAdvertisedServiceData(uuid, data, length);
+  return _advertisingData.setAdvertisedServiceData(uuid, data, length);
 }
 
-void BLELocalDevice::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
+bool BLELocalDevice::setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength)
 {
-  _advertisingData.setManufacturerData(manufacturerData, manufacturerDataLength);
+  return _advertisingData.setManufacturerData(manufacturerData, manufacturerDataLength);
 }
 
-void BLELocalDevice::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
+bool BLELocalDevice::setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength)
 {
-  _advertisingData.setManufacturerData(companyId, manufacturerData, manufacturerDataLength);
+  return _advertisingData.setManufacturerData(companyId, manufacturerData, manufacturerDataLength);
 }
 
-void BLELocalDevice::setLocalName(const char *localName)
+bool BLELocalDevice::setLocalName(const char *localName)
 {
-  _scanResponseData.setLocalName(localName);  
+  return _scanResponseData.setLocalName(localName);  
 }
 
 void BLELocalDevice::setAdvertisingData(BLEAdvertisingData& advertisingData)

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -42,12 +42,12 @@ public:
 
   virtual int rssi();
 
-  virtual void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
-  virtual void setAdvertisedService(const BLEService& service);
-  virtual void setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length);
-  virtual void setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
-  virtual void setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
-  virtual void setLocalName(const char *localName);
+  virtual bool setAdvertisedServiceUuid(const char* advertisedServiceUuid);
+  virtual bool setAdvertisedService(const BLEService& service);
+  virtual bool setAdvertisedServiceData(uint16_t uuid, const uint8_t data[], int length);
+  virtual bool setManufacturerData(const uint8_t manufacturerData[], int manufacturerDataLength);
+  virtual bool setManufacturerData(const uint16_t companyId, const uint8_t manufacturerData[], int manufacturerDataLength);
+  virtual bool setLocalName(const char *localName);
 
   virtual void setAdvertisingData(BLEAdvertisingData& advertisingData);
   virtual void setScanResponseData(BLEAdvertisingData& scanResponseData);


### PR DESCRIPTION
API functions to set the parameters of advertising data return a bool value:
-  'true' -> advertising parameter is correctly set
-  'false' -> advertising parameter is not set, there is not enough space in the packet to advertise it
<br>
Example sketch:
<br><br>

_Using standard advertising method_

```C++
#include <ArduinoBLE.h>

// Advertising parameters should have a global scope. Do NOT define them in 'setup' or in 'loop'
const uint8_t manufactData[4] = {0};
const uint8_t manufactDataLong[30] = {0};

void setup() 
{
  Serial.begin(9600);
  while (!Serial);

  if (!BLE.begin()) {
    Serial.println("failed to initialize BLE!");
    while (1);
  }

  bool success = BLE.setLocalName("Test advertising return type");
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }

  // Try to set a too long manufacturer data
  success = BLE.setManufacturerData(0x004C, manufactDataLong, sizeof(manufactDataLong));
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }
  // Set a shorter manufacturer data
  success = BLE.setManufacturerData(0x004C, manufactData, sizeof(manufactData));
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }

  BLE.advertise();
  Serial.println("advertising ...");
}

void loop() 
{
  BLE.poll();
}

```
<br>

_Using enhanced advertising method_

```C++
#include <ArduinoBLE.h>

// Advertising parameters should have a global scope. Do NOT define them in 'setup' or in 'loop'
const uint8_t manufactData[4] = {0};
const uint8_t manufactDataLong[30] = {0};

void setup() 
{
  Serial.begin(9600);
  while (!Serial);

  if (!BLE.begin()) {
    Serial.println("failed to initialize BLE!");
    while (1);
  }

  // Build scan response data packet
  BLEAdvertisingData scanData;
  bool success = scanData.setLocalName("Test advertising return type");
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }
  BLE.setScanResponseData(scanData);

  // Build advertising data packet
  BLEAdvertisingData advData;
  // Try to set a too long manufacturer data
  success = advData.setManufacturerData(0x004C, manufactDataLong, sizeof(manufactDataLong));
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }
  // Set a shorter manufacturer data
  success = advData.setManufacturerData(0x004C, manufactData, sizeof(manufactData));
  if (!success) { Serial.println("Failed to set parameter, not enough space available"); }
  BLE.setAdvertisingData(advData);

  BLE.advertise();
  Serial.println("advertising ...");
}

void loop() 
{
  BLE.poll();
}

```