### PR TITLE
Add enhanced advertising examples

### DIFF
--- a/examples/Peripheral/Advertising/EnhancedAdvertising/EnhancedAdvertising.ino
+++ b/examples/Peripheral/Advertising/EnhancedAdvertising/EnhancedAdvertising.ino
@@ -1,0 +1,44 @@
+#include <ArduinoBLE.h>
+
+BLEService myService("fff0");
+BLEIntCharacteristic myCharacteristic("fff1", BLERead | BLEBroadcast);
+
+// Advertising parameters should have a global scope. Do NOT define them in 'setup' or in 'loop'
+const uint8_t manufactData[4] = {0x01, 0x02, 0x03, 0x04};
+const uint8_t serviceData[3] = {0x00, 0x01, 0x02};
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+
+  if (!BLE.begin()) {
+    Serial.println("failed to initialize BLE!");
+    while (1);
+  }
+
+  myService.addCharacteristic(myCharacteristic);
+  BLE.addService(myService);
+
+  // Build scan response data packet
+  BLEAdvertisingData scanData;
+  // Set parameters for scan response packet
+  scanData.setLocalName("Test enhanced advertising");
+  // Copy set parameters in the actual scan response packet
+  BLE.setScanResponseData(scanData);
+
+  // Build advertising data packet
+  BLEAdvertisingData advData;
+  // Set parameters for advertising packet
+  advData.setManufacturerData(0x004C, manufactData, sizeof(manufactData));
+  advData.setAdvertisedService(myService);
+  advData.setAdvertisedServiceData(0xfff0, serviceData, sizeof(serviceData));
+  // Copy set parameters in the actual advertising packet
+  BLE.setAdvertisingData(advData);
+
+  BLE.advertise();
+  Serial.println("advertising ...");
+}
+
+void loop() {
+  BLE.poll();
+}

--- a/examples/Peripheral/Advertising/RawDataAdvertising/RawDataAdvertising.ino
+++ b/examples/Peripheral/Advertising/RawDataAdvertising/RawDataAdvertising.ino
@@ -1,0 +1,41 @@
+#include <ArduinoBLE.h>
+
+BLEService myService("fff0");
+BLEIntCharacteristic myCharacteristic("fff1", BLERead | BLEBroadcast);
+
+// Advertising parameters should have a global scope. Do NOT define them in 'setup' or in 'loop'
+const uint8_t completeRawAdvertisingData[] = {0x02,0x01,0x06,0x09,0xff,0x01,0x01,0x00,0x01,0x02,0x03,0x04,0x05};   
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+
+  if (!BLE.begin()) {
+    Serial.println("failed to initialize BLE!");
+    while (1);
+  }
+
+  myService.addCharacteristic(myCharacteristic);
+  BLE.addService(myService);
+
+  // Build advertising data packet
+  BLEAdvertisingData advData;
+  // If a packet has a raw data parameter, then all the other parameters of the packet will be ignored
+  advData.setRawData(completeRawAdvertisingData, sizeof(completeRawAdvertisingData));  
+  // Copy set parameters in the actual advertising packet
+  BLE.setAdvertisingData(advData);
+
+  // Build scan response data packet
+  BLEAdvertisingData scanData;
+  scanData.setLocalName("Test advertising raw data");
+  // Copy set parameters in the actual scan response packet
+  BLE.setScanResponseData(scanData);
+  
+  BLE.advertise();
+
+  Serial.println("advertising ...");
+}
+
+void loop() {
+  BLE.poll();
+}


### PR DESCRIPTION
While the old way of preparing advertising data is still supported, an alternative enhanced method to build advertising packets is now available.
It consists in defining and configuring an object of type 'BLEAdvertisingData' to build the desired packet.
When it has been configured, by setting the appropriate parameters, it can be used to populate the advertising data packet or the scan response data packet.
Following this way, the user can decide in which packet each parameter should be put.
Also, it is now possible to configure an advertising packet (advertising or scan response) by passing a raw data packet.
If an advertising packet has a raw data parameter set, all its other parameters will be ignored.

Also, advertising parameters such as manufacturer data, service data or raw data should have a GLOBAL scope, because they are passed as pointers and are not copied internally.

Example `EnhancedAdvertising.ino` shows how to build generic advertising and scan response packets.
Example `RawDataAdvertising.ino` shows how to configure an advertising packet given an already encoded raw advertising packet