### PR TITLE
Change advertising raw data setting

### DIFF
--- a/src/BLEAdvertisingData.cpp
+++ b/src/BLEAdvertisingData.cpp
@@ -186,7 +186,7 @@ bool BLEAdvertisingData::setLocalName(const char *localName)
 bool BLEAdvertisingData::setRawData(const uint8_t* data, int length)
 {
   if (length > MAX_AD_DATA_LENGTH) {
-    length = MAX_AD_DATA_LENGTH;
+    return false;
   }
   _rawData = data;
   _rawDataLength = length;
@@ -195,11 +195,11 @@ bool BLEAdvertisingData::setRawData(const uint8_t* data, int length)
 
 bool BLEAdvertisingData::setRawData(const BLEAdvertisingRawData& rawData)
 {
+  if (rawData.length > MAX_AD_DATA_LENGTH) {
+    return false;
+  }
   _rawData = rawData.data;
   _rawDataLength = rawData.length;
-  if (_rawDataLength > MAX_AD_DATA_LENGTH) {
-    _rawDataLength = MAX_AD_DATA_LENGTH;
-  }
   return true;
 }
 


### PR DESCRIPTION
If a BLEAdvertisingData packet has the raw data parameter set, all the other parameters are ignored when encoding the actual data packet.
This means that the raw data parameter can be as long as the maximum length for an advertising packet (MAX_AD_DATA_LENGTH), that is 31 bytes as per BLE standard.
During the setting of the raw data parameter: if the passed raw data length is larger than this maximum value, then the raw data is not set and the function returns false.