### PR TITLE
Add python script to make the output of serial debug analyzable through wireshark

### DIFF
--- a/extras/arduino-ble-parser.py
+++ b/extras/arduino-ble-parser.py
@@ -1,0 +1,88 @@
+'''
+Convert ArduinoBLE debug files into Btsnoop files ready to be analyzed using wireshark or hcidump
+Btsnoop file format reference
+ https://www.fte.com/WebHelpII/Sodera/Content/Technical_Information/BT_Snoop_File_Format.htm
+'''
+
+import  os
+import argparse
+
+DEBUG = False
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-i', dest='inputPath', type=str, required=True, help='input file containing debug log')
+parser.add_argument('-o', dest='outputPath', type=str, required=True, help='result file that will contain the btsnoop encoded debug file')
+args = parser.parse_args()
+
+# Extract only hci debug messages
+def extractHCIDebugPrint(inputPath, outputPath):
+  inputFile = open(inputPath, 'r')
+  outputFile = open(outputPath, 'w')
+  for inputLine in inputFile:
+    lineItems = inputLine.split()
+    if (len(lineItems) < 7) or (lineItems[1] != "->") or (lineItems[2] != "HCI"):
+      if (len(lineItems) < 4) or (lineItems[0] != "HCI") or ((lineItems[3] != "<-") and (lineItems[3] != "->")):
+        continue
+    outputFile.write(inputLine)  
+  outputFile.close()
+
+# Return packet in btsnoop format
+def buildBinaryPacket(hciMessage, hciDirection, hciType):
+  commandFlag = 1 if (hciType == "COMMAND" or hciType == "EVENT") else 0
+  directionFlag =  0 if (hciDirection == "TX") else 1
+  flagHex = ("0" * 7) + str((commandFlag * 2) + directionFlag)
+  timestampHex = "0" * 16
+  packetDropHex = "0" * 8
+  dataLengthHex = format( (len(hciMessage) / 2), 'x')
+  packetLengthHex = ("0" * (8 - len(dataLengthHex))) + dataLengthHex
+  binaryPacket = bytearray.fromhex(packetLengthHex + packetLengthHex + flagHex + packetDropHex + timestampHex + hciMessage)
+  if DEBUG:
+    print(binaryPacket)
+    print
+    print(len(hciMessage))
+    print(dataLengthHex)
+    print(packetLengthHex)
+    print (flagHex)
+    print
+    print(binaryPacket)
+  return binaryPacket
+
+def buildBinaryHeader():
+  defaultHeader = "6274736e6f6f700000000001000003ea"
+  binaryHeader = bytearray.fromhex(defaultHeader)
+  return binaryHeader;
+
+def convertToBtsnoop(inputPath, outputPath):
+  # Open output file and write the Btsnoop header
+  outputFile = open(outputPath,'wb')
+  header = buildBinaryHeader()
+  outputFile.write(header)
+
+  # Open input file containing HCI debug packets
+  inputFile = open(inputPath, 'r')
+  for inputLine in inputFile:
+    lineItems = inputLine.split()
+    # For a safer script, do not use indexes but look for symbols in the line
+    baseIndex = lineItems.index("HCI")
+    hciMessage = lineItems[baseIndex + 4]
+    hciDirection = lineItems[baseIndex + 2]
+    hciType = lineItems[baseIndex + 1]
+    # Build and write the encoded line
+    btsnoopPacket = buildBinaryPacket(hciMessage, hciDirection, hciType)
+    outputFile.write(btsnoopPacket)
+    if DEBUG:
+      print(hciDirection)
+      print(hciMessage)
+      print(hciType)
+      print()
+  outputFile.close()
+
+inputPath = args.inputPath
+outputPath = args.outputPath
+tempFile = "temp-debug-print.txt"
+# Run
+extractHCIDebugPrint(inputPath,tempFile)
+convertToBtsnoop(tempFile, outputPath)
+# Delete temp file
+os.remove(tempFile) 
+

--- a/extras/arduino-ble-parser.py
+++ b/extras/arduino-ble-parser.py
@@ -33,24 +33,21 @@ def buildBinaryPacket(hciMessage, hciDirection, hciType):
   flagHex = ("0" * 7) + str((commandFlag * 2) + directionFlag)
   timestampHex = "0" * 16
   packetDropHex = "0" * 8
-  dataLengthHex = format( (len(hciMessage) / 2), 'x')
+  dataLengthHex = format( (int(len(hciMessage) / 2)), 'x')
   packetLengthHex = ("0" * (8 - len(dataLengthHex))) + dataLengthHex
   binaryPacket = bytearray.fromhex(packetLengthHex + packetLengthHex + flagHex + packetDropHex + timestampHex + hciMessage)
   if DEBUG:
-    print(binaryPacket)
-    print
     print(len(hciMessage))
     print(dataLengthHex)
     print(packetLengthHex)
-    print (flagHex)
-    print
-    print(binaryPacket)
+    print(flagHex)
+    print('\n')
   return binaryPacket
 
 def buildBinaryHeader():
   defaultHeader = "6274736e6f6f700000000001000003ea"
   binaryHeader = bytearray.fromhex(defaultHeader)
-  return binaryHeader;
+  return binaryHeader
 
 def convertToBtsnoop(inputPath, outputPath):
   # Open output file and write the Btsnoop header
@@ -74,7 +71,7 @@ def convertToBtsnoop(inputPath, outputPath):
       print(hciDirection)
       print(hciMessage)
       print(hciType)
-      print()
+      print('\n')
   outputFile.close()
 
 inputPath = args.inputPath


### PR DESCRIPTION
This python script allows to encode the Serial debug output into a format that can be analyzed by wireshark and hcidump

Steps to debug:

- modify the sketch attaching Serial to BLE debug 'BLE.debug(Serial)'
- execute the sketch and open the arduino serial monitor
- save the content of the serial monitor in a file (here 'inputFile')
- execute the script with the following arguments: -i to specify the input file, -o to specify the output file
      `python your/script/path/arduino-ble-parser.py -i inputFile -o outputFile`
- using wireshark, simply open outputFile