### PR TITLE
Allocate dyamic sized arrays

### DIFF
--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -616,7 +616,7 @@ int HCIClass::tryResolveAddress(uint8_t* BDAddr, uint8_t* address){
   return 0;
 }
 
-int HCIClass::sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data)
+int HCIClass::sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, const void* data)
 {
   while (_pendingPkt >= _maxPkt) {
     poll();
@@ -673,7 +673,7 @@ void HCIClass::noDebug()
   _debug = NULL;
 }
 
-int HCIClass::sendCommand(uint16_t opcode, uint8_t plen, void* parameters)
+int HCIClass::sendCommand(uint16_t opcode, uint8_t plen, const void* parameters)
 {
   struct __attribute__ ((packed)) {
     uint8_t pktType;

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -630,7 +630,7 @@ int HCIClass::sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data)
     uint16_t cid;
   } aclHdr = { HCI_ACLDATA_PKT, handle, uint8_t(plen + 4), plen, cid };
 
-  uint8_t txBuffer[sizeof(aclHdr) + plen];
+  uint8_t *txBuffer = uint8_t*malloc(sizeof(aclHdr) + plen);
   memcpy(txBuffer, &aclHdr, sizeof(aclHdr));
   memcpy(&txBuffer[sizeof(aclHdr)], data, plen);
 
@@ -648,7 +648,8 @@ int HCIClass::sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data)
 
   _pendingPkt++;
   HCITransport.write(txBuffer, sizeof(aclHdr) + plen);
-
+  free(txBuffer);
+  
   return 0;
 }
 
@@ -680,7 +681,7 @@ int HCIClass::sendCommand(uint16_t opcode, uint8_t plen, void* parameters)
     uint8_t plen;
   } pktHdr = {HCI_COMMAND_PKT, opcode, plen};
 
-  uint8_t txBuffer[sizeof(pktHdr) + plen];
+  uint8_t *txBuffer = uint8_t*malloc(sizeof(pktHdr) + plen);
   memcpy(txBuffer, &pktHdr, sizeof(pktHdr));
   memcpy(&txBuffer[sizeof(pktHdr)], parameters, plen);
 
@@ -704,6 +705,8 @@ int HCIClass::sendCommand(uint16_t opcode, uint8_t plen, void* parameters)
   for (unsigned long start = millis(); _cmdCompleteOpcode != opcode && millis() < (start + 1000);) {
     poll();
   }
+
+  free(txBuffer);
 
   return _cmdCompleteStatus;
 }

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -630,7 +630,7 @@ int HCIClass::sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data)
     uint16_t cid;
   } aclHdr = { HCI_ACLDATA_PKT, handle, uint8_t(plen + 4), plen, cid };
 
-  uint8_t *txBuffer = uint8_t*malloc(sizeof(aclHdr) + plen);
+  uint8_t* txBuffer = (uint8_t*)malloc(sizeof(aclHdr) + plen);
   memcpy(txBuffer, &aclHdr, sizeof(aclHdr));
   memcpy(&txBuffer[sizeof(aclHdr)], data, plen);
 
@@ -681,7 +681,7 @@ int HCIClass::sendCommand(uint16_t opcode, uint8_t plen, void* parameters)
     uint8_t plen;
   } pktHdr = {HCI_COMMAND_PKT, opcode, plen};
 
-  uint8_t *txBuffer = uint8_t*malloc(sizeof(pktHdr) + plen);
+  uint8_t* txBuffer = (uint8_t*)malloc(sizeof(pktHdr) + plen);
   memcpy(txBuffer, &pktHdr, sizeof(pktHdr));
   memcpy(&txBuffer[sizeof(pktHdr)], parameters, plen);
 

--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -110,7 +110,7 @@ public:
   virtual int writeLK(uint8_t peerAddress[], uint8_t LK[]);
   virtual int tryResolveAddress(uint8_t* BDAddr, uint8_t* address);
 
-  virtual int sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data);
+  virtual int sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, const void* data);
 
   virtual int disconnect(uint16_t handle);
 
@@ -118,7 +118,7 @@ public:
   virtual void noDebug();
 
   // TODO: Send command be private again & use ATT implementation of send command within ATT.
-  virtual int sendCommand(uint16_t opcode, uint8_t plen = 0, void* parameters = NULL);
+  virtual int sendCommand(uint16_t opcode, uint8_t plen = 0, const void* parameters = nullptr);
   uint8_t remotePublicKeyBuffer[64];
   uint8_t localPublicKeyBuffer[64];
   uint8_t remoteDHKeyCheckBuffer[16];


### PR DESCRIPTION
In response to issue https://github.com/arduino-libraries/ArduinoBLE/issues/89 

Rather than make a variable sized buffer (is that somehow supported?), allocate a correctly sized buffer.

Alternative might be to have a fixed size TX buffer to avoid allocations/reallocations...