### PR TITLE
Cordio: remove call to reset sequence

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -211,7 +211,6 @@ int HCICordioTransportClass::begin()
   } 
 #else 
   CordioHCIHook::getDriver().initialize();
-  CordioHCIHook::getDriver().start_reset_sequence();
 #endif
 
   if (bleLoopThread == NULL) {


### PR DESCRIPTION
'NRFCordioHCIDriver::start_reset_sequence()' exploits the ble HOST stack of cordio. This is used to send a reset command to the controller.
ArduinoBLE doesn't use the cordio host stack and already sends a reset command to the controller during the initialization of the library.