### PR TITLE
Overload writeValue to allow forced write without response

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -234,65 +234,65 @@ int BLECharacteristic::readValue(int32_t& value)
   return readValue((uint8_t*)&value, sizeof(value));
 }
 
-int BLECharacteristic::writeValue(const uint8_t value[], int length)
+int BLECharacteristic::writeValue(const uint8_t value[], int length, bool withResponse)
 {
   if (_local) {
     return _local->writeValue(value, length);
   }
 
   if (_remote) {
-    return _remote->writeValue(value, length);
+    return _remote->writeValue(value, length, withResponse);
   }
 
   return 0;
 }
 
-int BLECharacteristic::writeValue(const void* value, int length)
+int BLECharacteristic::writeValue(const void* value, int length, bool withResponse)
 {
-  return writeValue((const uint8_t*)value, length);
+  return writeValue((const uint8_t*)value, length, withResponse);
 }
 
-int BLECharacteristic::writeValue(const char* value)
+int BLECharacteristic::writeValue(const char* value, bool withResponse)
 {
   if (_local) {
     return _local->writeValue(value);
   }
 
   if (_remote) {
-    return _remote->writeValue(value);
+    return _remote->writeValue(value, withResponse);
   }
 
   return 0;
 }
 
-int BLECharacteristic::writeValue(uint8_t value)
+int BLECharacteristic::writeValue(uint8_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
-int BLECharacteristic::writeValue(int8_t value)
+int BLECharacteristic::writeValue(int8_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
-int BLECharacteristic::writeValue(uint16_t value)
+int BLECharacteristic::writeValue(uint16_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
-int BLECharacteristic::writeValue(int16_t value)
+int BLECharacteristic::writeValue(int16_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
-int BLECharacteristic::writeValue(uint32_t value)
+int BLECharacteristic::writeValue(uint32_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
-int BLECharacteristic::writeValue(int32_t value)
+int BLECharacteristic::writeValue(int32_t value, bool withResponse)
 {
-  return writeValue((uint8_t*)&value, sizeof(value));
+  return writeValue((uint8_t*)&value, sizeof(value), withResponse);
 }
 
 int BLECharacteristic::broadcast()

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -68,15 +68,15 @@ public:
   int readValue(uint32_t& value);
   int readValue(int32_t& value);
 
-  int writeValue(const uint8_t value[], int length);
-  int writeValue(const void* value, int length);
-  int writeValue(const char* value);
-  int writeValue(uint8_t value);
-  int writeValue(int8_t value);
-  int writeValue(uint16_t value);
-  int writeValue(int16_t value);
-  int writeValue(uint32_t value);
-  int writeValue(int32_t value);
+  int writeValue(const uint8_t value[], int length, bool withResponse = true);
+  int writeValue(const void* value, int length, bool withResponse = true);
+  int writeValue(const char* value, bool withResponse = true);
+  int writeValue(uint8_t value, bool withResponse = true);
+  int writeValue(int8_t value, bool withResponse = true);
+  int writeValue(uint16_t value, bool withResponse = true);
+  int writeValue(int16_t value, bool withResponse = true);
+  int writeValue(uint32_t value, bool withResponse = true);
+  int writeValue(int32_t value, bool withResponse = true);
 
   // deprecated, use writeValue(...)
   int setValue(const uint8_t value[], int length) { return writeValue(value, length); }

--- a/src/remote/BLERemoteCharacteristic.cpp
+++ b/src/remote/BLERemoteCharacteristic.cpp
@@ -85,7 +85,7 @@ uint8_t BLERemoteCharacteristic::operator[] (int offset) const
   return 0;
 }
 
-int BLERemoteCharacteristic::writeValue(const uint8_t value[], int length)
+int BLERemoteCharacteristic::writeValue(const uint8_t value[], int length, bool withResponse)
 {
   if (!ATT.connected(_connectionHandle)) {
     return false;
@@ -104,7 +104,7 @@ int BLERemoteCharacteristic::writeValue(const uint8_t value[], int length)
     return 0;
   }
 
-  if (_properties & BLEWrite) {
+  if ((_properties & BLEWrite) && withResponse) {
     uint8_t resp[4];
     int respLength = ATT.writeReq(_connectionHandle, _valueHandle, value, length, resp);
 
@@ -133,9 +133,9 @@ int BLERemoteCharacteristic::writeValue(const uint8_t value[], int length)
   return 0;
 }
 
-int BLERemoteCharacteristic::writeValue(const char* value)
+int BLERemoteCharacteristic::writeValue(const char* value, bool withResponse)
 {
-  return writeValue((uint8_t*)value, strlen(value));
+  return writeValue((uint8_t*)value, strlen(value), withResponse);
 }
 
 bool BLERemoteCharacteristic::valueUpdated()

--- a/src/remote/BLERemoteCharacteristic.h
+++ b/src/remote/BLERemoteCharacteristic.h
@@ -38,8 +38,8 @@ public:
   int valueLength() const;
   uint8_t operator[] (int offset) const;
 
-  int writeValue(const uint8_t value[], int length);
-  int writeValue(const char* value);
+  int writeValue(const uint8_t value[], int length, bool withResponse = true);
+  int writeValue(const char* value, bool withResponse = true);
 
   bool valueUpdated();
   bool updatedValueRead();


### PR DESCRIPTION
When a characteristic is declared (Write | WriteWithoutResponse) the code always creates a request
and expects a response.
By setting withResponse=false the user can bypass the request and write a responseless command.

Reworks and supersedes https://github.com/arduino-libraries/ArduinoBLE/pull/72