### PR TITLE
Fix find info resp when called on non-descriptor attributes

### DIFF
--- a/src/local/BLELocalAttribute.h
+++ b/src/local/BLELocalAttribute.h
@@ -22,6 +22,8 @@
 
 #include "utility/BLEUuid.h"
 
+#define BLE_ATTRIBUTE_TYPE_SIZE 2
+
 enum BLEAttributeType {
   BLETypeUnknown        = 0x0000,
 

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -683,7 +683,8 @@ void ATTClass::findInfoReq(uint16_t connectionHandle, uint16_t mtu, uint8_t dlen
     BLELocalAttribute* attribute = GATT.attribute(i);
     uint16_t handle = (i + 1);
     bool isValueHandle = (attribute->type() == BLETypeCharacteristic) && (((BLELocalCharacteristic*)attribute)->valueHandle() == handle);
-    int uuidLen = isValueHandle ? 2 : attribute->uuidLength();
+    bool isDescriptor = attribute->type() == BLETypeDescriptor;
+    int uuidLen = (isValueHandle || isDescriptor) ? attribute->uuidLength() : BLE_ATTRIBUTE_TYPE_SIZE;
     int infoType = (uuidLen == 2) ? 0x01 : 0x02;
 
     if (response[1] == 0) {
@@ -699,7 +700,7 @@ void ATTClass::findInfoReq(uint16_t connectionHandle, uint16_t mtu, uint8_t dlen
     memcpy(&response[responseLength], &handle, sizeof(handle));
     responseLength += sizeof(handle);
 
-    if (isValueHandle || attribute->type() == BLETypeDescriptor) {
+    if (isValueHandle || isDescriptor) {
       // add the UUID
       memcpy(&response[responseLength], attribute->uuidData(), uuidLen);
       responseLength += uuidLen;


### PR DESCRIPTION
Before this fix, if the `ATT information request` was called on an handle belonging to a non-descriptor attribute, then the response would contain the uuid of the actual attribute's type but with the format of the attribute uuid (0x01 for 16 bit length, 0x02 for 128 bit length).
So, for instance, if the info request was performed on an handle belonging to a service with a uuid of 128 bit, then the response would have been malformed because the size of the attribute's type is 16 bit.

From issue discovered by @ThomasGerstenberg 
https://github.com/arduino-libraries/ArduinoBLE/issues/147