### PR TITLE
add access to raw advertisement data

### DIFF
--- a/src/BLEDevice.cpp
+++ b/src/BLEDevice.cpp
@@ -184,6 +184,17 @@ String BLEDevice::advertisedServiceUuid(int index) const
   return serviceUuid;
 }
 
+int BLEDevice::advertisementData(uint8_t value[], int length)
+{
+  if (_eirDataLength > length) return 0;  // Check that buffer size is sufficient
+
+  if (_eirDataLength) {
+    memcpy(value, _eirData, _eirDataLength);
+  }
+
+  return _eirDataLength;
+}
+
 int BLEDevice::rssi()
 {
   uint16_t handle = ATT.connectionHandle(_addressType, _address);

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -59,6 +59,8 @@ public:
   String advertisedServiceUuid() const;
   String advertisedServiceUuid(int index) const;
 
+  int advertisementData(uint8_t value[], int length);
+
   virtual int rssi();
 
   bool connect();


### PR DESCRIPTION
some sensors encode information in raw advertisement data, see issue #123. i added the code from @tarheele (and renamed the accessor to `advertisementData`).