### PR TITLE
Added missing method to access raw scan advertisement data

### DIFF
--- a/src/BLEDevice.cpp
+++ b/src/BLEDevice.cpp
@@ -184,6 +184,16 @@ String BLEDevice::advertisedServiceUuid(int index) const
   return serviceUuid;
 }
 
+int BLEDevice::getRawAdvertisement(uint8_t *value, int max_length)
+{
+  if (_eirDataLength <= max_length) {
+    memcpy(value, _eirData, _eirDataLength);
+    return _eirDataLength;
+  }
+
+  return 0; // buffer too small
+}
+
 int BLEDevice::rssi()
 {
   uint16_t handle = ATT.connectionHandle(_addressType, _address);

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -84,6 +84,7 @@ public:
   BLECharacteristic characteristic(int index) const;
   BLECharacteristic characteristic(const char * uuid) const;
   BLECharacteristic characteristic(const char * uuid, int index) const;
+  int getRawAdvertisement(uint8_t *value, int length);
 
 protected:
   friend class ATTClass;


### PR DESCRIPTION
The current ArduinoBLE library does not include a way to access the raw scan advertisement data even though it is received. I added a simple method to BLEDevice to accomplish this. Please consider merging this with the master branch.
