### PR TITLE
Update GitHub Actions workflows and action versions

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -4,20 +4,20 @@ on:
   - pull_request
 
 jobs:
- build:
-   runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-   strategy:
-     matrix:
-       fqbn:
-         - arduino:samd:mkrwifi1010
-         - arduino:samd:nano_33_iot
-         - arduino:megaavr:uno2018:mode=on
-         - arduino:mbed:nano33ble
+    strategy:
+      matrix:
+        fqbn:
+          - arduino:samd:mkrwifi1010
+          - arduino:samd:nano_33_iot
+          - arduino:megaavr:uno2018:mode=on
+          - arduino:mbed:nano33ble
 
-   steps:
-     - uses: actions/checkout@v2
-     - uses: arduino/compile-sketches@v1
-       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-         fqbn: ${{ matrix.fqbn }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.fqbn }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -14,9 +14,7 @@ jobs:
        ]
 
    steps:
-     - uses: actions/checkout@v1
-       with:
-         fetch-depth: 1
+     - uses: actions/checkout@v2
      - uses: arduino/actions/libraries/compile-examples@master
        with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,17 +1,19 @@
 name: Compile Examples
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
+
 jobs:
  build:
    runs-on: ubuntu-latest
 
    strategy:
      matrix:
-       fqbn: [
-         "arduino:samd:mkrwifi1010",
-         "arduino:samd:nano_33_iot",
-         "arduino:megaavr:uno2018:mode=on",
-         "arduino:mbed:nano33ble"
-       ]
+       fqbn:
+         - arduino:samd:mkrwifi1010
+         - arduino:samd:nano_33_iot
+         - arduino:megaavr:uno2018:mode=on
+         - arduino:mbed:nano33ble
 
    steps:
      - uses: actions/checkout@v2

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -15,7 +15,7 @@ jobs:
 
    steps:
      - uses: actions/checkout@v2
-     - uses: arduino/actions/libraries/compile-examples@master
+     - uses: arduino/compile-sketches@v1
        with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
          fqbn: ${{ matrix.fqbn }}


### PR DESCRIPTION
- Use latest releases of GitHub Actions actions in sketch compilation CI workflow (https://github.com/arduino-libraries/ArduinoBLE/commit/425e62d6cd1becc0da188850ca1c2eacc7f0c9e1, https://github.com/arduino-libraries/ArduinoBLE/commit/3f706db4d6496047c38ead5c78e5eac2119a64b2)
- Fix formatting of workflow (https://github.com/arduino-libraries/ArduinoBLE/commit/07965268a6cd5b4945fc212e850ae7038ae933d2, https://github.com/arduino-libraries/ArduinoBLE/commit/489830abebfa5b7fffe8f60464af9a084934dd3c)