### PR TITLE
add esp32 support

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Enables BLE connectivity on the Arduino MKR WiFi 1010, Arduino UNO WiFi
 paragraph=This library supports creating a BLE peripheral and BLE central mode.
 category=Communication
 url=https://www.arduino.cc/en/Reference/ArduinoBLE
-architectures=samd,megaavr,mbed,apollo3,mbed_nano,mbed_portenta
+architectures=samd,megaavr,mbed,apollo3,mbed_nano,mbed_portenta,esp32
 includes=ArduinoBLE.h

--- a/src/utility/HCIUartTransport.cpp
+++ b/src/utility/HCIUartTransport.cpp
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if !defined(ARDUINO_ARCH_MBED) || defined(TARGET_NANO_RP2040_CONNECT)
+#if !defined(ARDUINO_ARCH_MBED) && !defined(ESP32) || defined(TARGET_NANO_RP2040_CONNECT)
 
 #include "HCIUartTransport.h"
 

--- a/src/utility/HCIVirtualTransport.cpp
+++ b/src/utility/HCIVirtualTransport.cpp
@@ -82,11 +82,7 @@ int HCIVirtualTransportClass::begin()
   }
   ESP_ERROR_CHECK( ret );
   esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-#if CONFIG_IDF_TARGET_ESP32C3
-	bt_cfg.bluetooth_mode = ESP_BT_MODE_BLE;
-#else
 	bt_cfg.mode = ESP_BT_MODE_BLE;
-#endif
   ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
   if (ret) {
       return 0;

--- a/src/utility/HCIVirtualTransport.cpp
+++ b/src/utility/HCIVirtualTransport.cpp
@@ -1,0 +1,147 @@
+/*
+  This file is part of the ArduinoBLE library.
+  Copyright (c) 2018 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#if defined(ESP32)
+
+#include "HCIVirtualTransport.h"
+
+StreamBufferHandle_t rec_buffer;
+StreamBufferHandle_t send_buffer;
+
+
+static void notify_host_send_available(void)
+{
+}
+
+static int notify_host_recv(uint8_t *data, uint16_t length)
+{
+  for (uint8_t i = 0; i < length; i++) {
+    char b = data[i];
+  }
+	xStreamBufferSend(rec_buffer,data,length,portMAX_DELAY);  // !!!potentially waiting forever
+  return 0;
+}
+
+static esp_vhci_host_callback_t vhci_host_cb = {
+  notify_host_send_available,
+  notify_host_recv
+};
+
+void bleTask(void *pvParameters)
+{
+  esp_vhci_host_register_callback(&vhci_host_cb);
+	size_t length;
+	uint8_t mybuf[256];
+
+  while(true){
+		length = xStreamBufferReceive(send_buffer,mybuf,256,portMAX_DELAY);
+		while (!esp_vhci_host_check_send_available()) {}
+    for (uint8_t i = 0; i < length; i++) {
+      char b = mybuf[i];
+    }
+    esp_vhci_host_send_packet(mybuf, length);
+  }
+}
+
+
+HCIVirtualTransportClass::HCIVirtualTransportClass()
+{
+}
+
+HCIVirtualTransportClass::~HCIVirtualTransportClass()
+{
+}
+
+int HCIVirtualTransportClass::begin()
+{
+	btStarted(); // this somehow stops the arduino ide from initializing bluedroid
+
+	rec_buffer = xStreamBufferCreate(258, 1);
+  send_buffer = xStreamBufferCreate(258, 1);
+
+  esp_err_t ret = nvs_flash_init();
+  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+      ESP_ERROR_CHECK(nvs_flash_erase());
+      ret = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK( ret );
+  esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+	bt_cfg.mode = ESP_BT_MODE_BLE;
+  ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+  if (ret) {
+      return 0;
+  }
+  if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) {
+      return 0;
+  }
+  if ((ret = esp_bt_controller_enable(ESP_BT_MODE_BLE)) != ESP_OK) {
+      return 0;
+  }
+  xTaskCreatePinnedToCore(&bleTask, "bleTask", 2048, NULL, 5, NULL, 0);
+  return 1;
+}
+
+void HCIVirtualTransportClass::end()
+{
+	vStreamBufferDelete(rec_buffer);
+  vStreamBufferDelete(send_buffer);
+  esp_bt_controller_deinit();
+}
+
+void HCIVirtualTransportClass::wait(unsigned long timeout)
+{
+  for (unsigned long start = (esp_timer_get_time() / 1000ULL); ((esp_timer_get_time() / 1000ULL) - start) < timeout;) {
+    if (available()) {
+      break;
+    }
+  }
+}
+
+int HCIVirtualTransportClass::available()
+{
+  size_t bytes	= xStreamBufferBytesAvailable(rec_buffer);
+  return bytes;
+}
+
+// never called
+int HCIVirtualTransportClass::peek()
+{
+  return -1;
+}
+
+int HCIVirtualTransportClass::read()
+{
+	uint8_t c;
+	if(xStreamBufferReceive(rec_buffer, &c, 1, portMAX_DELAY)) {
+    return c;
+  }
+  return -1;
+}
+
+size_t HCIVirtualTransportClass::write(const uint8_t* data, size_t length)
+{
+	size_t result = xStreamBufferSend(send_buffer,data,length,portMAX_DELAY);
+  return result;
+}
+
+HCIVirtualTransportClass HCIVirtualTransport;
+
+HCITransportInterface& HCITransport = HCIVirtualTransport;
+
+#endif

--- a/src/utility/HCIVirtualTransport.cpp
+++ b/src/utility/HCIVirtualTransport.cpp
@@ -82,7 +82,11 @@ int HCIVirtualTransportClass::begin()
   }
   ESP_ERROR_CHECK( ret );
   esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+#if CONFIG_IDF_TARGET_ESP32C3
+	bt_cfg.bluetooth_mode = ESP_BT_MODE_BLE;
+#else
 	bt_cfg.mode = ESP_BT_MODE_BLE;
+#endif
   ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
   if (ret) {
       return 0;

--- a/src/utility/HCIVirtualTransport.cpp
+++ b/src/utility/HCIVirtualTransport.cpp
@@ -82,7 +82,11 @@ int HCIVirtualTransportClass::begin()
   }
   ESP_ERROR_CHECK( ret );
   esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+#if CONFIG_IDF_TARGET_ESP32C3
+  bt_cfg.bluetooth_mode = ESP_BT_MODE_BLE;
+#else
   bt_cfg.mode = ESP_BT_MODE_BLE;
+#endif
   ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
   if (ret) {
     return 0;

--- a/src/utility/HCIVirtualTransport.h
+++ b/src/utility/HCIVirtualTransport.h
@@ -1,0 +1,50 @@
+/*
+  This file is part of the ArduinoBLE library.
+  Copyright (c) 2018 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "HCITransport.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/stream_buffer.h"
+
+#include "esp_bt.h"
+#include "nvs_flash.h"
+
+#include "esp32-hal-bt.h" // this is needed to disable bluedroid
+
+
+class HCIVirtualTransportClass : public HCITransportInterface {
+public:
+  HCIVirtualTransportClass();
+  virtual ~HCIVirtualTransportClass();
+
+  virtual int begin();
+  virtual void end();
+
+  virtual void wait(unsigned long timeout);
+
+  virtual int available();
+  virtual int peek();
+  virtual int read();
+
+  virtual size_t write(const uint8_t* data, size_t length);
+};


### PR DESCRIPTION
Added support for the esp32 chip using the virtual HCI. This has been tested on real hardware with "Arduino core for the ESP32" version 2.0.0.