### PR TITLE
RP2040: Fix for arduino nano targets

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if defined(ARDUINO_ARCH_MBED) && !defined(TARGET_NANO_RP2040_CONNECT)
+#if defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_NANO_RP2040_CONNECT)
 
 #include <Arduino.h>
 #include <mbed.h>

--- a/src/utility/HCIUartTransport.cpp
+++ b/src/utility/HCIUartTransport.cpp
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if !defined(ARDUINO_ARCH_MBED) || defined(TARGET_NANO_RP2040_CONNECT)
+#if !defined(ARDUINO_ARCH_MBED) || defined(ARDUINO_NANO_RP2040_CONNECT)
 
 #include "HCIUartTransport.h"
 


### PR DESCRIPTION
Building a trivial ArduinoBLE sketch in the Arduino Web IDE fails when building for Arduino Nano RP2040 Connect.

```
// ArduinoBLE - Version: 1.2.0
#include <ArduinoBLE.h>

void setup() {
  Serial.begin(9600);
  while (!Serial);

  // begin initialization
  if (!BLE.begin()) {
    Serial.println("starting BLE failed!");

    while (1);
  }
  Serial.println("Yay!");
}

void loop() {
  Serial.println("Doin' stuff.");
}
```

Errors out with

```
/home/builder/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-g++ -c -w -g3 -nostdlib @/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/defines.txt @/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/cxxflags.txt -DARDUINO_ARCH_RP2040 -mcpu=cortex-m0plus -w -x c++ -E -CC -DARDUINO=10611 -DARDUINO_NANO_RP2040_CONNECT -DARDUINO_ARCH_MBED_NANO -DARDUINO_ARCH_MBED -DARDUINO_LIBRARY_DISCOVERY_PHASE=1 -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/cores/arduino -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT -I/home/builder/opt/libraries/latest/arduinoble_1_2_0/src -I/home/builder/opt/libraries/latest/arduino_lsm6dsox_1_0_0/src -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/libraries/Wire -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/libraries/SPI -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/cores/arduino/api/deprecated -I/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/cores/arduino/api/deprecated-avr-comp -iprefix/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/cores/arduino @/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/includes.txt /home/builder/opt/libraries/latest/arduinoble_1_2_0/src/utility/HCICordioTransport.cpp -o /dev/null

Alternatives for driver/CordioHCITransportDriver.h: []

ResolveLibrary(driver/CordioHCITransportDriver.h)

-> candidates: []

Using library arduinoble_1_2_0 at version 1.2.0 in folder: /home/builder/opt/libraries/latest/arduinoble_1_2_0

Using library arduino_lsm6dsox_1_0_0 at version 1.0.0 in folder: /home/builder/opt/libraries/latest/arduino_lsm6dsox_1_0_0

Using library Wire in folder: /home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/libraries/Wire (legacy)

Using library SPI in folder: /home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/libraries/SPI (legacy)

/home/builder/opt/libraries/latest/arduinoble_1_2_0/src/utility/HCICordioTransport.cpp:25:10: fatal error: driver/CordioHCITransportDriver.h: No such file or directory

#include <driver/CordioHCITransportDriver.h>

^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

compilation terminated.

exit status 1
```

The entire failing source file is wrapped in a preprocessor conditional that's looking at the wrong DEFINE - note in the above build output the compiler flag `-DARDUINO_NANO_RP2040_CONNECT`.  The preproc conditional is looking for TARGET_NANO_RP2040_CONNECT, which is incorrect.

I uploaded a zip of my fork to the web ide, and built the trivial sketch successfully with it:
```
/home/builder/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-g++ -L/tmp/623116598/build -Wl,--gc-sections -w -Wl,--as-needed @/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/ldflags.txt -T/home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/linker_script.ld -Wl,-Map,/tmp/623116598/build/sketch_may17a.ino.map --specs=nosys.specs -o /tmp/623116598/build/sketch_may17a.ino.elf /tmp/623116598/build/sketch/sketch_may17a.ino.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLEAdvertisingData.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLECharacteristic.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLEDescriptor.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLEDevice.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLEService.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLEStringCharacteristic.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/BLETypedCharacteristics.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/local/BLELocalAttribute.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/local/BLELocalCharacteristic.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/local/BLELocalDescriptor.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/local/BLELocalDevice.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/local/BLELocalService.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/remote/BLERemoteAttribute.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/remote/BLERemoteCharacteristic.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/remote/BLERemoteDescriptor.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/remote/BLERemoteDevice.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/remote/BLERemoteService.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/ATT.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/BLEUuid.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/GAP.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/GATT.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/HCI.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/HCICordioTransport.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/HCIUartTransport.cpp.o /tmp/623116598/build/libraries/ArduinoBLE/utility/L2CAPSignaling.cpp.o /tmp/623116598/build/core/double_tap_usb_boot.cpp.o /tmp/623116598/build/core/variant.cpp.o -Wl,--whole-archive /tmp/623116598/build/../../core/core_arduino_mbed_nano_nanorp2040connect_948efc9e30b9863e3f218744164947b5.a /home/builder/.arduino15/packages/arduino/hardware/mbed_nano/2.1.0/variants/NANO_RP2040_CONNECT/libs/libmbed.a -Wl,--no-whole-archive -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group

/home/builder/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-objcopy -O binary /tmp/623116598/build/sketch_may17a.ino.elf /tmp/623116598/build/sketch_may17a.ino.bin

/home/builder/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-objcopy -O ihex -R .eeprom /tmp/623116598/build/sketch_may17a.ino.elf /tmp/623116598/build/sketch_may17a.ino.hex

Multiple libraries were found for "ArduinoBLE.h"

Used: /tmp/623116598/custom/ArduinoBLE

Not used: /home/builder/opt/libraries/latest/arduinoble_1_2_0

Not used: /tmp/623116598/pinned/arduinoble_1_2_0

Using library ArduinoBLE at version 1.2.0 in folder: /tmp/623116598/custom/ArduinoBLE

/home/builder/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/arm-none-eabi-size -A /tmp/623116598/build/sketch_may17a.ino.elf

Sketch uses 99396 bytes (0%) of program storage space. Maximum is 16777216 bytes.

Global variables use 54384 bytes (20%) of dynamic memory, leaving 215952 bytes for local variables. Maximum is 270336 bytes.
```

I am unable to validate that this allows it to actually work on hardware (it's ordered, but not yet arrived), but it compiles without error, and appears to be what was intended.