### PR TITLE
fix potential arrary overflow problem of _recvBuffer

### DIFF
--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -113,7 +113,7 @@ void HCIClass::poll(unsigned long timeout)
   while (HCITransport.available()) {
     byte b = HCITransport.read();
 	
-	if (sizeof(_recvBuffer) <= _recvIndex)
+	if (_recvIndex >= sizeof(_recvBuffer))
 	{
 	  _recvIndex = 0;
 	  if (_debug) {

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -115,6 +115,9 @@ void HCIClass::poll(unsigned long timeout)
 	
     if (_recvIndex >= sizeof(_recvBuffer)) {
         _recvIndex = 0;
+        if (_debug) {
+            _debug->println("_recvBuffer overflow");
+        }
     }
 
     _recvBuffer[_recvIndex++] = b;

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -113,14 +113,9 @@ void HCIClass::poll(unsigned long timeout)
   while (HCITransport.available()) {
     byte b = HCITransport.read();
 	
-	if (_recvIndex >= sizeof(_recvBuffer))
-	{
-	  _recvIndex = 0;
-	  if (_debug) {
-			_debug->println("_recvBuffer overflow");
-		  }
-	  continue;
-	}
+    if (_recvIndex >= sizeof(_recvBuffer)) {
+        _recvIndex = 0;
+    }
 
     _recvBuffer[_recvIndex++] = b;
 

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -112,6 +112,15 @@ void HCIClass::poll(unsigned long timeout)
 
   while (HCITransport.available()) {
     byte b = HCITransport.read();
+	
+	if (sizeof(_recvBuffer) <= _recvIndex)
+	{
+	  _recvIndex = 0;
+	  if (_debug) {
+			_debug->println("_recvBuffer overflow");
+		  }
+	  continue;
+	}
 
     _recvBuffer[_recvIndex++] = b;
 


### PR DESCRIPTION
I find that when I use my nano 33 ble with this BLE lib.
Sometimes when I use the demo project ScanCallback.ino,
my program freezes because of the overflow of _recvBuffer.