### PR TITLE
Definition for known format types.

### DIFF
--- a/src/definitions/BLEDefinitions.h
+++ b/src/definitions/BLEDefinitions.h
@@ -17,13 +17,9 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _ARDUINO_BLE_H_
-#define _ARDUINO_BLE_H_
+#ifndef _BLE_DEFINITIONS_H_
+#define _BLE_DEFINITIONS_H_
 
-#include "definitions/BLEDefinitions.h"
-#include "local/BLELocalDevice.h"
-#include "BLEProperty.h"
-#include "BLEStringCharacteristic.h"
-#include "BLETypedCharacteristics.h"
+#include "BLEFormatTypes.h"
 
 #endif

--- a/src/definitions/BLEFormatTypes.h
+++ b/src/definitions/BLEFormatTypes.h
@@ -1,0 +1,43 @@
+/*
+  This file is part of the ArduinoBLE library.
+  Copyright (c) 2018 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _BLE_FORMAT_TYPES_H_
+#define _BLE_FORMAT_TYPES_H_
+
+const char BleBoolean[] = "\x01"; /* unsigned 1-bit integer, 0-false, 1-true */
+const char Ble2bit[] = "\x02"; /* unsigned 2-bit integer */
+const char BleNibble[] = "\x03"; /* unsigned 4-bit integer */
+const char BleUint8[] = "\x04"; /* unsigned 8-bit integer */
+const char BleUint12[] = "\x05"; /* unsigned 12-bit integer */
+const char BleUint16[] = "\x06"; /* unsigned 16-bit integer */
+const char BleUint24[] = "\x07"; /* unsigned 24-bit integer */
+const char BleUint32[] = "\x08"; /* unsigned 32-bit integer */
+const char BleUint48[] = "\x09"; /* unsigned 48-bit integer */
+const char BleUint64[] = "\x0A"; /* unsigned 64-bit integer */
+const char BleUint128[] = "\x0B"; /* unsigned 128-bit integer */
+const char BleInt8[] = "\x0C"; /* signed 8-bit integer */
+const char BleInt12[] = "\x0D"; /* signed 12-bit integer */
+const char BleInt16[] = "\x0E"; /* signed 16-bit integer */
+const char BleInt24[] = "\x0F"; /* signed 24-bit integer */
+const char BleInt32[] = "\x10"; /* signed 32-bit integer */
+const char BleInt48[] = "\x11"; /* signed 48-bit integer */
+const char BleInt64[] = "\x12"; /* signed 64-bit integer */
+const char BleInt128[] = "\x13"; /* signed 128-bit integer */
+
+#endif


### PR DESCRIPTION
To simplify usage of the ArduinoBLE, I added the definitions for format types.
In the future I would like to add also known services and characteristics uuid codes.

I check with the Arduino compiler that the definitions are included in result binary only if they are used by the code. So no extra space will be taken, Please review and tell what do you think about the idea. I find it more useful than searching the internet for proper values.

I has been forced to use char type, as Description constructor does not accept the `uint8_t` type as input for value.
`BLEDescriptor::BLEDescriptor(const char* uuid, const uint8_t value[], int valueSize)`
`BLEDescriptor::BLEDescriptor(const char* uuid, const char* value)`