### PR TITLE
Mixed naming of central and peripheral in examples

### DIFF
--- a/examples/Peripheral/CallbackLED/CallbackLED.ino
+++ b/examples/Peripheral/CallbackLED/CallbackLED.ino
@@ -49,9 +49,9 @@ void setup() {
   // add service
   BLE.addService(ledService);
 
-  // assign event handlers for connected, disconnected to peripheral
-  BLE.setEventHandler(BLEConnected, blePeripheralConnectHandler);
-  BLE.setEventHandler(BLEDisconnected, blePeripheralDisconnectHandler);
+  // assign event handlers for connected, disconnected to central
+  BLE.setEventHandler(BLEConnected, bleCentralConnectedHandler);
+  BLE.setEventHandler(BLEDisconnected, bleCentralDisconnectedHandler);
 
   // assign event handlers for characteristic
   switchCharacteristic.setEventHandler(BLEWritten, switchCharacteristicWritten);
@@ -69,13 +69,13 @@ void loop() {
   BLE.poll();
 }
 
-void blePeripheralConnectHandler(BLEDevice central) {
+void bleCentralConnectedHandler(BLEDevice central) {
   // central connected event handler
   Serial.print("Connected event, central: ");
   Serial.println(central.address());
 }
 
-void blePeripheralDisconnectHandler(BLEDevice central) {
+void bleCentralDisconnectedHandler(BLEDevice central) {
   // central disconnected event handler
   Serial.print("Disconnected event, central: ");
   Serial.println(central.address());

--- a/examples/Peripheral/LED/LED.ino
+++ b/examples/Peripheral/LED/LED.ino
@@ -58,7 +58,7 @@ void setup() {
 }
 
 void loop() {
-  // listen for Bluetooth® Low Energy peripherals to connect:
+  // listen for Bluetooth® Low Energy central to connect:
   BLEDevice central = BLE.central();
 
   // if a central is connected to peripheral:


### PR DESCRIPTION
Fixed the names and comments to not confuse the users.

The BLE central can start connection to peripheral, not vice versa.

The most confusing one was that we wait for peripherals to connect, and next comment name the variable that it is central. :)
```
  // listen for Bluetooth® Low Energy peripherals to connect:
  BLEDevice central = BLE.central();
```