### PR TITLE
Bugfix: memory leak caused by variables not being deleted in end()

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -72,11 +72,11 @@ BLECharacteristic::BLECharacteristic(const BLECharacteristic& other)
 
 BLECharacteristic::~BLECharacteristic()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/BLEDescriptor.cpp
+++ b/src/BLEDescriptor.cpp
@@ -72,11 +72,11 @@ BLEDescriptor::BLEDescriptor(const BLEDescriptor& other)
 
 BLEDescriptor::~BLEDescriptor()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/BLEService.cpp
+++ b/src/BLEService.cpp
@@ -65,11 +65,11 @@ BLEService::BLEService(const BLEService& other)
 
 BLEService::~BLEService()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/local/BLELocalCharacteristic.cpp
+++ b/src/local/BLELocalCharacteristic.cpp
@@ -62,7 +62,7 @@ BLELocalCharacteristic::~BLELocalCharacteristic()
   for (unsigned int i = 0; i < descriptorCount(); i++) {
     BLELocalDescriptor* d = descriptor(i);
 
-    if (d->release() <= 0) {
+    if (d->release() == 0) {
       delete d;
     }
   }

--- a/src/local/BLELocalService.cpp
+++ b/src/local/BLELocalService.cpp
@@ -33,7 +33,7 @@ BLELocalService::~BLELocalService()
   for (unsigned int i = 0; i < characteristicCount(); i++) {
     BLELocalCharacteristic* c = characteristic(i);
 
-    if (c->release() <= 0) {
+    if (c->release() == 0) {
       delete c;
     }
   }

--- a/src/remote/BLERemoteCharacteristic.cpp
+++ b/src/remote/BLERemoteCharacteristic.cpp
@@ -44,7 +44,7 @@ BLERemoteCharacteristic::~BLERemoteCharacteristic()
   for (unsigned int i = 0; i < descriptorCount(); i++) {
     BLERemoteDescriptor* d = descriptor(i);
 
-    if (d->release() <= 0) {
+    if (d->release() == 0) {
       delete d;
     }
   }

--- a/src/remote/BLERemoteDevice.cpp
+++ b/src/remote/BLERemoteDevice.cpp
@@ -50,7 +50,7 @@ void BLERemoteDevice::clearServices()
   for (unsigned int i = 0; i < serviceCount(); i++) {
     BLERemoteService* s = service(i);
 
-    if (s->release() <= 0) {
+    if (s->release() == 0) {
       delete s;
     }
   }

--- a/src/remote/BLERemoteService.cpp
+++ b/src/remote/BLERemoteService.cpp
@@ -31,7 +31,7 @@ BLERemoteService::~BLERemoteService()
   for (unsigned int i = 0; i < characteristicCount(); i++) {
     BLERemoteCharacteristic* c = characteristic(i);
 
-    if (c->release() <= 0) {
+    if (c->release() == 0) {
       delete c;
     }
   }

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -70,11 +70,21 @@ void GATTClass::begin()
 
 void GATTClass::end()
 {
-  delete(_genericAccessService);
-  delete(_deviceNameCharacteristic);
-  delete(_appearanceCharacteristic);
-  delete(_genericAttributeService);
-  delete(_servicesChangedCharacteristic);
+  if (_genericAccessService->release() <= 0)
+    delete(_genericAccessService);
+  
+  if (_deviceNameCharacteristic->release() <= 0)
+    delete(_deviceNameCharacteristic);
+  
+  if (_appearanceCharacteristic->release() <= 0)
+    delete(_appearanceCharacteristic);
+  
+  if (_genericAttributeService->release() <= 0)
+    delete(_genericAttributeService);
+  
+  if (_servicesChangedCharacteristic->release() <= 0)
+    delete(_servicesChangedCharacteristic);
+  
   clearAttributes();
 }
 

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -70,7 +70,12 @@ void GATTClass::begin()
 
 void GATTClass::end()
 {
-  _attributes.clear();
+  delete(_genericAccessService);
+  delete(_deviceNameCharacteristic);
+  delete(_appearanceCharacteristic);
+  delete(_genericAttributeService);
+  delete(_servicesChangedCharacteristic);
+  clearAttributes();
 }
 
 void GATTClass::setDeviceName(const char* deviceName)

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -38,7 +38,7 @@ GATTClass::GATTClass() :
 
 GATTClass::~GATTClass()
 {
-  clearAttributes();
+  end();
 }
 
 void GATTClass::begin()

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -70,19 +70,19 @@ void GATTClass::begin()
 
 void GATTClass::end()
 {
-  if (_genericAccessService->release() <= 0)
+  if (_genericAccessService->release() == 0)
     delete(_genericAccessService);
   
-  if (_deviceNameCharacteristic->release() <= 0)
+  if (_deviceNameCharacteristic->release() == 0)
     delete(_deviceNameCharacteristic);
   
-  if (_appearanceCharacteristic->release() <= 0)
+  if (_appearanceCharacteristic->release() == 0)
     delete(_appearanceCharacteristic);
   
-  if (_genericAttributeService->release() <= 0)
+  if (_genericAttributeService->release() == 0)
     delete(_genericAttributeService);
   
-  if (_servicesChangedCharacteristic->release() <= 0)
+  if (_servicesChangedCharacteristic->release() == 0)
     delete(_servicesChangedCharacteristic);
   
   clearAttributes();

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -179,7 +179,7 @@ void GATTClass::clearAttributes()
   for (unsigned int i = 0; i < attributeCount(); i++) {
     BLELocalAttribute* a = attribute(i);
 
-    if (a->release() <= 0) {
+    if (a->release() == 0) {
       delete a;
     }
   }

--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -234,7 +234,10 @@ void HCICordioTransportClass::end()
     delete bleLoopThread;
     bleLoopThread = NULL;
   }
+
+#if !defined(ARDUINO_PORTENTA_H7_M4) && !defined(ARDUINO_PORTENTA_H7_M7) && !defined(ARDUINO_NICLA_VISION)
   CordioHCIHook::getDriver().terminate();
+#endif
 
   _begun = false;
 }


### PR DESCRIPTION
This pull request addresses the issue described in #192 caused by variables initialized in begin() not being deleted in end(). This leads to hangs and crashes reported also in other issues.