### PR TITLE
Bugfix: prevent reference counting from accessing freed memory

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -72,11 +72,11 @@ BLECharacteristic::BLECharacteristic(const BLECharacteristic& other)
 
 BLECharacteristic::~BLECharacteristic()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/BLEDescriptor.cpp
+++ b/src/BLEDescriptor.cpp
@@ -72,11 +72,11 @@ BLEDescriptor::BLEDescriptor(const BLEDescriptor& other)
 
 BLEDescriptor::~BLEDescriptor()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/BLEService.cpp
+++ b/src/BLEService.cpp
@@ -65,11 +65,11 @@ BLEService::BLEService(const BLEService& other)
 
 BLEService::~BLEService()
 {
-  if (_local && _local->release() <= 0) {
+  if (_local && _local->release() == 0) {
     delete _local;
   }
 
-  if (_remote && _remote->release() <= 0) {
+  if (_remote && _remote->release() == 0) {
     delete _remote;
   }
 }

--- a/src/local/BLELocalAttribute.cpp
+++ b/src/local/BLELocalAttribute.cpp
@@ -19,9 +19,10 @@
 
 #include "BLELocalAttribute.h"
 
+std::map<BLELocalAttribute*,int> BLELocalAttribute::_refCount;
+
 BLELocalAttribute::BLELocalAttribute(const char* uuid) :
-  _uuid(uuid),
-  _refCount(0)
+  _uuid(uuid)
 {
 }
 
@@ -51,14 +52,15 @@ enum BLEAttributeType BLELocalAttribute::type() const
 
 int BLELocalAttribute::retain()
 {
-  _refCount++;
+  _refCount[this]++;
 
-  return _refCount;
+  return _refCount[this];
 }
 
 int BLELocalAttribute::release()
 {
-  _refCount--;
+  _refCount[this]--;
+  if (_refCount[this] == 0) _refCount.erase(this);
 
-  return _refCount;
+  return _refCount[this];
 }

--- a/src/local/BLELocalAttribute.cpp
+++ b/src/local/BLELocalAttribute.cpp
@@ -19,7 +19,9 @@
 
 #include "BLELocalAttribute.h"
 
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
 std::map<BLELocalAttribute*,int> BLELocalAttribute::_refCount;
+#endif
 
 BLELocalAttribute::BLELocalAttribute(const char* uuid) :
   _uuid(uuid)
@@ -52,15 +54,21 @@ enum BLEAttributeType BLELocalAttribute::type() const
 
 int BLELocalAttribute::retain()
 {
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   _refCount[this]++;
-
   return _refCount[this];
+#else
+  return -1;
+#endif
 }
 
 int BLELocalAttribute::release()
 {
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   _refCount[this]--;
   if (_refCount[this] == 0) _refCount.erase(this);
-
   return _refCount[this];
+#else
+  return -1;
+#endif
 }

--- a/src/local/BLELocalAttribute.h
+++ b/src/local/BLELocalAttribute.h
@@ -22,6 +22,8 @@
 
 #include "utility/BLEUuid.h"
 
+#include <map>
+
 #define BLE_ATTRIBUTE_TYPE_SIZE 2
 
 enum BLEAttributeType {
@@ -54,7 +56,7 @@ protected:
 
 private:
   BLEUuid _uuid;
-  int _refCount;
+  static std::map<BLELocalAttribute*,int> _refCount;
 };
 
 #endif

--- a/src/local/BLELocalAttribute.h
+++ b/src/local/BLELocalAttribute.h
@@ -22,7 +22,9 @@
 
 #include "utility/BLEUuid.h"
 
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
 #include <map>
+#endif
 
 #define BLE_ATTRIBUTE_TYPE_SIZE 2
 
@@ -56,7 +58,10 @@ protected:
 
 private:
   BLEUuid _uuid;
+
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   static std::map<BLELocalAttribute*,int> _refCount;
+#endif
 };
 
 #endif

--- a/src/local/BLELocalCharacteristic.cpp
+++ b/src/local/BLELocalCharacteristic.cpp
@@ -62,7 +62,7 @@ BLELocalCharacteristic::~BLELocalCharacteristic()
   for (unsigned int i = 0; i < descriptorCount(); i++) {
     BLELocalDescriptor* d = descriptor(i);
 
-    if (d->release() <= 0) {
+    if (d->release() == 0) {
       delete d;
     }
   }

--- a/src/local/BLELocalService.cpp
+++ b/src/local/BLELocalService.cpp
@@ -33,7 +33,7 @@ BLELocalService::~BLELocalService()
   for (unsigned int i = 0; i < characteristicCount(); i++) {
     BLELocalCharacteristic* c = characteristic(i);
 
-    if (c->release() <= 0) {
+    if (c->release() == 0) {
       delete c;
     }
   }

--- a/src/remote/BLERemoteAttribute.cpp
+++ b/src/remote/BLERemoteAttribute.cpp
@@ -21,9 +21,10 @@
 
 #include "BLERemoteAttribute.h"
 
+std::map<BLERemoteAttribute*,int> BLERemoteAttribute::_refCount;
+
 BLERemoteAttribute::BLERemoteAttribute(const uint8_t uuid[], uint8_t uuidLen) :
-  _uuid(BLEUuid::uuidToString(uuid, uuidLen)),
-  _refCount(0)
+  _uuid(BLEUuid::uuidToString(uuid, uuidLen))
 {
 }
 
@@ -38,14 +39,15 @@ const char* BLERemoteAttribute::uuid() const
 
 int BLERemoteAttribute::retain()
 {
-  _refCount++;
+  _refCount[this]++;
 
-  return _refCount;
+  return _refCount[this];
 }
 
 int BLERemoteAttribute::release()
 {
-  _refCount--;
+  _refCount[this]--;
+  if (_refCount[this] == 0) _refCount.erase(this);
 
-  return _refCount;
+  return _refCount[this];
 }

--- a/src/remote/BLERemoteAttribute.cpp
+++ b/src/remote/BLERemoteAttribute.cpp
@@ -21,7 +21,9 @@
 
 #include "BLERemoteAttribute.h"
 
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
 std::map<BLERemoteAttribute*,int> BLERemoteAttribute::_refCount;
+#endif
 
 BLERemoteAttribute::BLERemoteAttribute(const uint8_t uuid[], uint8_t uuidLen) :
   _uuid(BLEUuid::uuidToString(uuid, uuidLen))
@@ -39,15 +41,21 @@ const char* BLERemoteAttribute::uuid() const
 
 int BLERemoteAttribute::retain()
 {
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   _refCount[this]++;
-
   return _refCount[this];
+#else
+  return -1;
+#endif
 }
 
 int BLERemoteAttribute::release()
 {
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   _refCount[this]--;
   if (_refCount[this] == 0) _refCount.erase(this);
-
   return _refCount[this];
+#else
+  return -1;
+#endif
 }

--- a/src/remote/BLERemoteAttribute.h
+++ b/src/remote/BLERemoteAttribute.h
@@ -21,6 +21,7 @@
 #define _BLE_REMOTE_ATTRIBUTE_H_
 
 #include <Arduino.h>
+#include <map>
 
 class BLERemoteAttribute
 {
@@ -35,7 +36,7 @@ public:
 
 private:
   String _uuid;
-  int _refCount;
+  static std::map<BLERemoteAttribute*,int> _refCount;
 };
 
 #endif

--- a/src/remote/BLERemoteAttribute.h
+++ b/src/remote/BLERemoteAttribute.h
@@ -21,7 +21,10 @@
 #define _BLE_REMOTE_ATTRIBUTE_H_
 
 #include <Arduino.h>
+
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
 #include <map>
+#endif
 
 class BLERemoteAttribute
 {
@@ -36,7 +39,10 @@ public:
 
 private:
   String _uuid;
+
+#ifndef ARDUINO_AVR_UNO_WIFI_REV2
   static std::map<BLERemoteAttribute*,int> _refCount;
+#endif
 };
 
 #endif

--- a/src/remote/BLERemoteCharacteristic.cpp
+++ b/src/remote/BLERemoteCharacteristic.cpp
@@ -43,7 +43,7 @@ BLERemoteCharacteristic::~BLERemoteCharacteristic()
   for (unsigned int i = 0; i < descriptorCount(); i++) {
     BLERemoteDescriptor* d = descriptor(i);
 
-    if (d->release() <= 0) {
+    if (d->release() == 0) {
       delete d;
     }
   }

--- a/src/remote/BLERemoteDevice.cpp
+++ b/src/remote/BLERemoteDevice.cpp
@@ -50,7 +50,7 @@ void BLERemoteDevice::clearServices()
   for (unsigned int i = 0; i < serviceCount(); i++) {
     BLERemoteService* s = service(i);
 
-    if (s->release() <= 0) {
+    if (s->release() == 0) {
       delete s;
     }
   }

--- a/src/remote/BLERemoteService.cpp
+++ b/src/remote/BLERemoteService.cpp
@@ -31,7 +31,7 @@ BLERemoteService::~BLERemoteService()
   for (unsigned int i = 0; i < characteristicCount(); i++) {
     BLERemoteCharacteristic* c = characteristic(i);
 
-    if (c->release() <= 0) {
+    if (c->release() == 0) {
       delete c;
     }
   }

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -164,7 +164,7 @@ void GATTClass::clearAttributes()
   for (unsigned int i = 0; i < attributeCount(); i++) {
     BLELocalAttribute* a = attribute(i);
 
-    if (a->release() <= 0) {
+    if (a->release() == 0) {
       delete a;
     }
   }


### PR DESCRIPTION
The `BLELocalAttribute` and `BLERemoteAttribute` classes implement a rudimentary reference counting mechanism:

```c++
int BLELocalAttribute::retain()
{
  _refCount++;

  return _refCount;
}

int BLELocalAttribute::release()
{
  _refCount--;

  return _refCount;
}
```

However, `_refCount` is an instance variable so every call to `release()` on a pointer that was already deleted will try to access freed memory, defeating the purpose of refcounting. A more modern solution would be to replace this with `std::shared_ptr`, but this pull request provides a minimalistic fix based on making `_refCount` a static class variable that lives outside the lifecycle of the instance.

I noticed this issue after merging #237.