### PR TITLE
Update HCI.h

### DIFF
--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -35,7 +35,7 @@ enum LE_COMMAND {
   ENCRYPT                      = 0x0017,
   RANDOM                       = 0x0018,
   LONG_TERM_KEY_REPLY          = 0x001A,
-  LONG_TERM_KEY_NEGATIVE_REPLY = 0x1B,
+  LONG_TERM_KEY_NEGATIVE_REPLY = 0x001B,
   READ_LOCAL_P256              = 0x0025,
   GENERATE_DH_KEY_V1           = 0x0026,
   GENERATE_DH_KEY_V2           = 0x005E


### PR DESCRIPTION
Kindly See the Docs, https://www.bluetooth.com/specifications/specs/core-specification-4-2/
In Pg. No: 1316/2772, you Can See "7.8.26 LE Long Term Key Request Negative Reply Command".
Kindly See the OFC Code, it is 0x001B.