### PR TITLE
Change non returning functions to void + spelling

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -1272,7 +1272,7 @@ void ATTClass::writeReqOrCmd(uint16_t connectionHandle, uint16_t mtu, uint8_t op
       }
       return;
     }
-    // Check permssion
+    // Check permission
     if((characteristic->permissions() &( BLEPermission::BLEEncryption >> 8)) > 0 && 
        (getPeerEncryption(connectionHandle) & PEER_ENCRYPTION::ENCRYPTED_AES) == 0){
       holdResponse = true;

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -460,14 +460,14 @@ int HCIClass::leConnUpdate(uint16_t handle, uint16_t minInterval, uint16_t maxIn
 
   return sendCommand(OGF_LE_CTL << 10 | OCF_LE_CONN_UPDATE, sizeof(leConnUpdateData), &leConnUpdateData);
 }
-int HCIClass::saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* localIrk){
+void HCIClass::saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* localIrk){
   if(_storeIRK!=0){
     _storeIRK(address, peerIrk);
   }
   // Again... this should work 
   // leAddResolvingAddress(addressType, address, peerIrk, localIrk);
 }
-int HCIClass::leAddResolvingAddress(uint8_t addressType, uint8_t* peerAddress, uint8_t* peerIrk, uint8_t* localIrk){
+void HCIClass::leAddResolvingAddress(uint8_t addressType, uint8_t* peerAddress, uint8_t* peerIrk, uint8_t* localIrk){
   leStopResolvingAddresses();
 
   struct __attribute__ ((packed)) AddDevice {
@@ -527,7 +527,7 @@ int HCIClass::leReadPeerResolvableAddress(uint8_t peerAddressType, uint8_t* peer
   return res;
 }
 
-int HCIClass::writeLK(uint8_t peerAddress[], uint8_t LK[]){
+void HCIClass::writeLK(uint8_t peerAddress[], uint8_t LK[]){
   struct __attribute__ ((packed)) StoreLK {
     uint8_t nKeys;
     uint8_t BD_ADDR[6];
@@ -538,7 +538,7 @@ int HCIClass::writeLK(uint8_t peerAddress[], uint8_t LK[]){
   for(int i=0; i<16; i++) storeLK.LTK[15-i] = LK[i];
   HCI.sendCommand(OGF_HOST_CTL << 10 | 0x11, sizeof(storeLK), &storeLK);
 }
-int HCIClass::readStoredLKs(){
+void HCIClass::readStoredLKs(){
   uint8_t BD_ADDR[6];
   readStoredLK(BD_ADDR, 1);
 }

--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -99,15 +99,15 @@ public:
   virtual AuthReq localAuthreq();
   virtual uint8_t localIOCap();
 
-  virtual int saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* remoteIrk);
-  virtual int leAddResolvingAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* remoteIrk);
+  virtual void saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* remoteIrk);
+  virtual void leAddResolvingAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* remoteIrk);
   virtual int leStopResolvingAddresses();
   virtual int leStartResolvingAddresses();
   virtual int leReadPeerResolvableAddress(uint8_t peerAddressType, uint8_t* peerIdentityAddress, uint8_t* peerResolvableAddress);
 
-  virtual int readStoredLKs();
+  virtual void readStoredLKs();
   virtual int readStoredLK(uint8_t BD_ADDR[], uint8_t read_all = 0);
-  virtual int writeLK(uint8_t peerAddress[], uint8_t LK[]);
+  virtual void writeLK(uint8_t peerAddress[], uint8_t LK[]);
   virtual int tryResolveAddress(uint8_t* BDAddr, uint8_t* address);
 
   virtual int sendAclPkt(uint16_t handle, uint8_t cid, uint8_t plen, void* data);


### PR DESCRIPTION
Very small change to get rid of compiler warnings. It also shrunk my program by 16850 bytes which is a nice benefit.