### PR TITLE
Fix hard fault when str is NULL

### DIFF
--- a/src/utility/BLEUuid.cpp
+++ b/src/utility/BLEUuid.cpp
@@ -30,6 +30,11 @@ BLEUuid::BLEUuid(const char * str) :
   memset(_data, 0x00, sizeof(_data));
 
   _length = 0;
+
+  if (str == NULL) {
+    return;
+  }
+
   for (int i = strlen(str) - 1; i >= 0 && _length < BLE_UUID_MAX_LENGTH; i -= 2) {
     if (str[i] == '-') {
       i++;


### PR DESCRIPTION
[BLEDevice::discoverService](https://github.com/stm32duino/STM32duinoBLE/blob/061ec8e7902ab1754a65264787f704d4bb265766/src/BLEDevice.cpp#L205) execute `ATT.discoverAttributes(_addressType, _address, NULL)` passing NULL as 3rd argument, that is eventually passed to [BLEUuid constructor](https://github.com/stm32duino/STM32duinoBLE/blob/061ec8e7902ab1754a65264787f704d4bb265766/src/utility/BLEUuid.cpp#L33) where it is used in `strlen(str)`.

Since dereferencing null pointer is UB, we should avoid to call `strlen(len)`.