### PR TITLE
Fix memory leak on end() -> begin() -> end()

### DIFF
--- a/src/BLEService.cpp
+++ b/src/BLEService.cpp
@@ -63,6 +63,13 @@ BLEService::BLEService(const BLEService& other)
   }
 }
 
+void BLEService::clear()
+{
+  if (_local) {
+    _local->clear();
+  }
+}
+
 BLEService::~BLEService()
 {
   if (_local && _local->release() == 0) {

--- a/src/BLEService.h
+++ b/src/BLEService.h
@@ -33,6 +33,7 @@ public:
   virtual ~BLEService();
 
   const char* uuid() const;
+  void clear();
 
   void addCharacteristic(BLECharacteristic& characteristic);
 

--- a/src/local/BLELocalAttribute.cpp
+++ b/src/local/BLELocalAttribute.cpp
@@ -56,6 +56,11 @@ int BLELocalAttribute::retain()
   return _refCount;
 }
 
+bool BLELocalAttribute::active()
+{
+  return _refCount > 0;
+}
+
 int BLELocalAttribute::release()
 {
   _refCount--;

--- a/src/local/BLELocalAttribute.h
+++ b/src/local/BLELocalAttribute.h
@@ -44,6 +44,7 @@ public:
 
   int retain();
   int release();
+  bool active();
 
 protected:
   friend class ATTClass;

--- a/src/local/BLELocalCharacteristic.cpp
+++ b/src/local/BLELocalCharacteristic.cpp
@@ -46,6 +46,7 @@ BLELocalCharacteristic::BLELocalCharacteristic(const char* uuid, uint16_t permis
   if (permissions & (BLENotify | BLEIndicate)) {
     BLELocalDescriptor* cccd = new BLELocalDescriptor("2902", (uint8_t*)&_cccdValue, sizeof(_cccdValue));
   
+    cccd->retain();
     _descriptors.add(cccd);
   }
 

--- a/src/local/BLELocalService.cpp
+++ b/src/local/BLELocalService.cpp
@@ -28,6 +28,12 @@ BLELocalService::BLELocalService(const char* uuid) :
 {
 }
 
+void BLELocalService::clear() {
+  _characteristics.clear();
+  _startHandle = 0;
+  _endHandle = 0;
+}
+
 BLELocalService::~BLELocalService()
 {
   for (unsigned int i = 0; i < characteristicCount(); i++) {
@@ -37,8 +43,7 @@ BLELocalService::~BLELocalService()
       delete c;
     }
   }
-
-  _characteristics.clear();
+  clear();
 }
 
 enum BLEAttributeType BLELocalService::type() const

--- a/src/local/BLELocalService.h
+++ b/src/local/BLELocalService.h
@@ -36,6 +36,7 @@ public:
   virtual enum BLEAttributeType type() const;
 
   void addCharacteristic(BLECharacteristic& characteristic);
+  void clear();
 
 protected:
   friend class ATTClass;

--- a/src/utility/GATT.cpp
+++ b/src/utility/GATT.cpp
@@ -149,6 +149,7 @@ void GATTClass::addService(BLELocalService* service)
 {
   service->retain();
   _attributes.add(service);
+  _services.add(service);
 
   uint16_t startHandle = attributeCount();
 
@@ -160,6 +161,7 @@ void GATTClass::addService(BLELocalService* service)
     characteristic->setHandle(attributeCount());
     
     // add the characteristic again to make space of the characteristic value handle
+    characteristic->retain();
     _attributes.add(characteristic);
 
     for (unsigned int j = 0; j < characteristic->descriptorCount(); j++) {
@@ -183,8 +185,13 @@ void GATTClass::clearAttributes()
       delete a;
     }
   }
-
   _attributes.clear();
+
+  for (unsigned int i = 0; i < _services.size(); i++) {
+    _services.get(i)->clear();
+  }
+  _services.clear();
+
 }
 
 #if !defined(FAKE_GATT)

--- a/src/utility/GATT.h
+++ b/src/utility/GATT.h
@@ -59,6 +59,7 @@ private:
 
 private:
   BLELinkedList<BLELocalAttribute*> _attributes;
+  BLELinkedList<BLELocalService*>   _services;
 
   BLELocalService*              _genericAccessService;
   BLELocalCharacteristic*       _deviceNameCharacteristic;


### PR DESCRIPTION
Should fix #243 and maybe some other memory related issues.

Only tested in Peripheral mode, with services and characteristics allocated:
* as global objects (arduino way)
* in function stack
* in heap

On mbed-enabled platforms, the memory check can be activated via

```

  ....
  mbed_stats_heap_t heap_stats;
  mbed_stats_heap_get(&heap_stats);
  Serial.print("Heap size: ");
  Serial.print(heap_stats.current_size);
  Serial.print(" / ");
  Serial.println(heap_stats.reserved_size);
  ....
```