### PR TITLE
Add support for passive scans

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ BLE.setEventHandler(eventType, callback)
 
 #### Parameters
 
-- **eventType**: event type (BLEConnected, BLEDisconnected)
+- **eventType**: event type (BLEConnected, BLEDisconnected, BLEDiscovered, BLEAdvertised)
 - **callback**: function to call when event occurs
 #### Returns
 Nothing.
@@ -812,12 +812,14 @@ Start scanning for Bluetooth® Low Energy devices that are advertising.
 ```
 BLE.scan()
 BLE.scan(withDuplicates)
+BLE.scan(withDuplicates, activeScan)
 
 ```
 
 #### Parameters
 
 - **withDuplicates:** optional, defaults to **false**. If **true**, advertisements received more than once will not be filtered
+- **activeScan:** optional, defaults to **true**. If **true**, an active scan is performed. Otherwise a passive scan is performed.
 
 #### Returns
 - 1 on success, 
@@ -859,6 +861,7 @@ Start scanning for Bluetooth® Low Energy devices that are advertising with a pa
 ```
 BLE.scanForName(name)
 BLE.scanForName(name, withDuplicates)
+BLE.scanForName(name, withDuplicates, activeScan)
 
 ```
 
@@ -866,6 +869,8 @@ BLE.scanForName(name, withDuplicates)
 
 -  **name:** (local) name of device (as a **String**) to filter for
 - **withDuplicates:** optional, defaults to **false**. If **true**, advertisements received more than once will not be filtered.
+- **activeScan:** optional, defaults to **true**. If **true**, an active scan is performed. Otherwise a passive scan is performed.
+Note that it is not common to include the name is a passive advertisement. For most device an active scan should be used when scanning for name.
 
 #### Returns
 - 1 on success,
@@ -907,6 +912,7 @@ Start scanning for Bluetooth® Low Energy devices that are advertising with a pa
 ```
 BLE.scanForAddress(address)
 BLE.scanForAddress(address, withDuplicates)
+BLE.scanForAddress(address, withDuplicates, activeScan)
 
 ```
 
@@ -914,6 +920,7 @@ BLE.scanForAddress(address, withDuplicates)
 
 - **address:** (Bluetooth®) address (as a String) to filter for
 - **withDuplicates:** optional, defaults to **false**. If **true**, advertisements received more than once will not be filtered
+- **activeScan:** optional, defaults to **true**. If **true**, an active scan is performed. Otherwise a passive scan is performed.
 
 #### Returns
 - 1 on success, 
@@ -955,6 +962,7 @@ Start scanning for Bluetooth® Low Energy devices that are advertising with a pa
 ```
 BLE.scanForUuid(uuid)
 BLE.scanForUuid(uuid, withDuplicates)
+BLE.scanForUuid(uuid, withDuplicates, activeScan)
 
 ```
 
@@ -962,6 +970,7 @@ BLE.scanForUuid(uuid, withDuplicates)
 
 - **uuid:** (service) UUID (as a **String**) to filter for
 - **withDuplicates:** optional, defaults to **false**. If **true**, advertisements received more than once will not be filtered.
+- **activeScan:** optional, defaults to **true**. If **true**, an active scan is performed. Otherwise a passive scan is performed.
 
 #### Returns
 - 1 on success,
@@ -1042,12 +1051,13 @@ Query for a discovered Bluetooth® Low Energy device that was found during scann
 
 ```
 BLE.available()
+BLE.available(includeAdvertised)
 
 ```
 
 #### Parameters
 
-Nothing
+- **includeAdvertised:** optional, defaults to **false**. If **true**, also devices for which only the passive advertise data is known are returned.
 
 #### Returns
 - **BLEDevice** representing the discovered device.

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -28,6 +28,7 @@ enum BLEDeviceEvent {
   BLEConnected = 0,
   BLEDisconnected = 1,
   BLEDiscovered = 2,
+  BLEAdvertised = 3,
 
   BLEDeviceLastEvent
 };

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -335,24 +335,24 @@ void BLELocalDevice::stopAdvertise()
   GAP.stopAdvertise();
 }
 
-int BLELocalDevice::scan(bool withDuplicates)
+int BLELocalDevice::scan(bool withDuplicates, bool activeScan)
 {
-  return GAP.scan(withDuplicates);
+  return GAP.scan(withDuplicates, activeScan);
 }
 
-int BLELocalDevice::scanForName(String name, bool withDuplicates)
+int BLELocalDevice::scanForName(String name, bool withDuplicates, bool activeScan)
 {
-  return GAP.scanForName(name, withDuplicates);
+  return GAP.scanForName(name, withDuplicates, activeScan);
 }
 
-int BLELocalDevice::scanForUuid(String uuid, bool withDuplicates)
+int BLELocalDevice::scanForUuid(String uuid, bool withDuplicates, bool activeScan)
 {
-  return GAP.scanForUuid(uuid, withDuplicates);
+  return GAP.scanForUuid(uuid, withDuplicates, activeScan);
 }
 
-int BLELocalDevice::scanForAddress(String address, bool withDuplicates)
+int BLELocalDevice::scanForAddress(String address, bool withDuplicates, bool activeScan)
 {
-  return GAP.scanForAddress(address, withDuplicates);
+  return GAP.scanForAddress(address, withDuplicates, activeScan);
 }
 
 void BLELocalDevice::stopScan()
@@ -367,16 +367,16 @@ BLEDevice BLELocalDevice::central()
   return ATT.central();
 }
 
-BLEDevice BLELocalDevice::available()
+BLEDevice BLELocalDevice::available(bool includeAdvertised)
 {
   HCI.poll();
 
-  return GAP.available();
+  return GAP.available(includeAdvertised);
 }
 
 void BLELocalDevice::setEventHandler(BLEDeviceEvent event, BLEDeviceEventHandler eventHandler)
 {
-  if (event == BLEDiscovered) {
+  if (event == BLEDiscovered || event == BLEAdvertised) {
     GAP.setEventHandler(event, eventHandler);
   } else {
     ATT.setEventHandler(event, eventHandler);

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -66,14 +66,14 @@ public:
   virtual int advertise();
   virtual void stopAdvertise();
 
-  virtual int scan(bool withDuplicates = false);
-  virtual int scanForName(String name, bool withDuplicates = false);
-  virtual int scanForUuid(String uuid, bool withDuplicates = false);
-  virtual int scanForAddress(String address, bool withDuplicates = false);
+  virtual int scan(bool withDuplicates = false, bool activeScan = true);
+  virtual int scanForName(String name, bool withDuplicates = false, bool activeScan = true);
+  virtual int scanForUuid(String uuid, bool withDuplicates = false, bool activeScan = true);
+  virtual int scanForAddress(String address, bool withDuplicates = false, bool activeScan = true);
   virtual void stopScan();
 
   virtual BLEDevice central();
-  virtual BLEDevice available();
+  virtual BLEDevice available(bool includeAdvertised = false);
 
   virtual void setAdvertisingInterval(uint16_t advertisingInterval);
   virtual void setConnectionInterval(uint16_t minimumConnectionInterval, uint16_t maximumConnectionInterval);

--- a/src/utility/GAP.h
+++ b/src/utility/GAP.h
@@ -33,12 +33,12 @@ public:
   virtual int advertise(uint8_t* advData, uint8_t advDataLength, uint8_t* scanData, uint8_t scanDataLength);
   virtual void stopAdvertise();
 
-  virtual int scan(bool withDuplicates);
-  virtual int scanForName(String name, bool withDuplicates);
-  virtual int scanForUuid(String uuid, bool withDuplicates);
-  virtual int scanForAddress(String address, bool withDuplicates);
+  virtual int scan(bool withDuplicates, bool activeScan = true);
+  virtual int scanForName(String name, bool withDuplicates, bool activeScan = true);
+  virtual int scanForUuid(String uuid, bool withDuplicates, bool activeScan = true);
+  virtual int scanForAddress(String address, bool withDuplicates, bool activeScan = true);
   virtual void stopScan();
-  virtual BLEDevice available();
+  virtual BLEDevice available(bool includeAdvertised = false);
 
   virtual void setAdvertisingInterval(uint16_t advertisingInterval);
   virtual void setConnectable(bool connectable);
@@ -62,6 +62,7 @@ private:
   bool _connectable;
 
   BLEDeviceEventHandler _discoverEventHandler;
+  BLEDeviceEventHandler _advertiseEventHandler;
   BLELinkedList<BLEDevice*> _discoveredDevices;
 
   String _scanNameFilter;


### PR DESCRIPTION
Add support for passive scans. In my case (crowded BLE environment), a passive scan detects devices a lot faster and more reliably. In additional, a passive scan consumes less power as the BLE radio is not transmitting.

Also added the ability to retrieve the devices for which only advertise data is available. That's what you are typically interested in when doing a passive scan.