### PR TITLE
Add function to manage low power mode status

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -478,7 +478,7 @@ void BLELocalDevice::noDebug()
   HCI.noDebug();
 }
 
-void BLELocalDevice::setLowPowerMode(bool status)
+void BLELocalDevice::setLowPowerModeEnabled(bool enabled)
 {
   HCI.leSetLPMode(status);
 }

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -478,6 +478,11 @@ void BLELocalDevice::noDebug()
   HCI.noDebug();
 }
 
+void BLELocalDevice::setLowPowerMode(bool status)
+{
+  HCI.leSetLPMode(status);
+}
+
 #if !defined(FAKE_BLELOCALDEVICE)
 BLELocalDevice BLEObj;
 BLELocalDevice& BLE = BLEObj;

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -480,7 +480,7 @@ void BLELocalDevice::noDebug()
 
 void BLELocalDevice::setLowPowerModeEnabled(bool enabled)
 {
-  HCI.leSetLPMode(status);
+  HCI.leSetLPMode(enabled);
 }
 
 #if !defined(FAKE_BLELOCALDEVICE)

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -107,6 +107,9 @@ public:
 
   virtual void setDisplayCode(void (*displayCode)(uint32_t confirmationCode));
   virtual void setBinaryConfirmPairing(bool (*binaryConfirmPairing)());
+
+  virtual void setLowPowerMode(bool status);
+
   uint8_t BDaddress[6];
   
 protected:

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -108,7 +108,7 @@ public:
   virtual void setDisplayCode(void (*displayCode)(uint32_t confirmationCode));
   virtual void setBinaryConfirmPairing(bool (*binaryConfirmPairing)());
 
-  virtual void setLowPowerMode(bool status);
+  virtual void setLowPowerModeEnabled(bool enabled);
 
   uint8_t BDaddress[6];
   

--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -1481,6 +1481,11 @@ void HCIClass::dumpPkt(const char* prefix, uint8_t plen, uint8_t pdata[])
   }
 }
 
+void HCIClass::leSetLPMode(bool status)
+{
+  HCITransport.setLPMode(status);
+}
+
 #if !defined(FAKE_HCI)
 HCIClass HCIObj;
 HCIClass& HCI = HCIObj;

--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -105,6 +105,8 @@ public:
   virtual int leStartResolvingAddresses();
   virtual int leReadPeerResolvableAddress(uint8_t peerAddressType, uint8_t* peerIdentityAddress, uint8_t* peerResolvableAddress);
 
+  virtual void leSetLPMode(bool status);
+
   virtual void readStoredLKs();
   virtual int readStoredLK(uint8_t BD_ADDR[], uint8_t read_all = 0);
   virtual void writeLK(uint8_t peerAddress[], uint8_t LK[]);

--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -54,6 +54,7 @@
 #endif
 
 extern BLE_NAMESPACE::CordioHCIDriver& ble_cordio_get_hci_driver();
+extern void ble_cordio_set_lp_mode(bool status);
 
 namespace BLE_NAMESPACE {
   struct CordioHCIHook {
@@ -67,6 +68,10 @@ namespace BLE_NAMESPACE {
 
     static void setDataReceivedHandler(void (*handler)(uint8_t*, uint8_t)) {
       getTransportDriver().set_data_received_handler(handler);
+    }
+
+    static void setLowPowerMode(bool status) {
+      ble_cordio_set_lp_mode(status);
     }
   };
 }
@@ -307,6 +312,11 @@ HCITransportInterface& HCITransport = HCICordioTransport;
 void HCICordioTransportClass::onDataReceived(uint8_t* data, uint8_t len)
 {
   HCICordioTransport.handleRxData(data, len);
+}
+
+void HCICordioTransportClass::setLPMode(bool status) 
+{
+  CordioHCIHook::setLowPowerMode(status);
 }
 
 #endif

--- a/src/utility/HCICordioTransport.h
+++ b/src/utility/HCICordioTransport.h
@@ -42,6 +42,8 @@ public:
 
   virtual size_t write(const uint8_t* data, size_t length);
 
+  virtual void setLPMode(bool status);
+
 private:
   static void onDataReceived(uint8_t* data, uint8_t len);
   void handleRxData(uint8_t* data, uint8_t len);

--- a/src/utility/HCITransport.h
+++ b/src/utility/HCITransport.h
@@ -34,6 +34,8 @@ public:
   virtual int read() = 0;
 
   virtual size_t write(const uint8_t* data, size_t length) = 0;
+
+  virtual void setLPMode(bool status);
 };
 
 extern HCITransportInterface& HCITransport;

--- a/src/utility/HCIUartTransport.cpp
+++ b/src/utility/HCIUartTransport.cpp
@@ -97,6 +97,11 @@ size_t HCIUartTransportClass::write(const uint8_t* data, size_t length)
   return result;
 }
 
+void HCIUartTransportClass::setLPMode(bool status) 
+{
+  (void)status;
+}
+
 #if defined(ARDUINO_AVR_UNO_WIFI_REV2) || defined(ARDUINO_NANO_RP2040_CONNECT)
 HCIUartTransportClass HCIUartTransport(SerialHCI, 119600);
 #else

--- a/src/utility/HCIUartTransport.h
+++ b/src/utility/HCIUartTransport.h
@@ -38,6 +38,8 @@ public:
 
   virtual size_t write(const uint8_t* data, size_t length);
 
+  virtual void setLPMode(bool status);
+  
 private:
   HardwareSerial* _uart;
   unsigned long _baudrate;

--- a/src/utility/HCIVirtualTransport.cpp
+++ b/src/utility/HCIVirtualTransport.cpp
@@ -135,6 +135,11 @@ size_t HCIVirtualTransportClass::write(const uint8_t* data, size_t length)
   return result;
 }
 
+void HCIVirtualTransportClass::setLPMode(bool status) 
+{
+  (void)status;
+}
+
 HCIVirtualTransportClass HCIVirtualTransport;
 
 HCITransportInterface& HCITransport = HCIVirtualTransport;

--- a/src/utility/HCIVirtualTransport.h
+++ b/src/utility/HCIVirtualTransport.h
@@ -47,4 +47,6 @@ public:
   virtual int read();
 
   virtual size_t write(const uint8_t* data, size_t length);
+
+  virtual void setLPMode(bool status);
 };

--- a/src/utility/HCIVirtualTransportAT.cpp
+++ b/src/utility/HCIVirtualTransportAT.cpp
@@ -105,6 +105,11 @@ size_t HCIVirtualTransportATClass::write(const uint8_t* data, size_t length)
   return 0;
 }
 
+void HCIVirtualTransportATClass::setLPMode(bool status) 
+{
+  (void)status;
+}
+
 HCIVirtualTransportATClass HCIVirtualTransportAT;
 
 HCITransportInterface& HCITransport = HCIVirtualTransportAT;

--- a/src/utility/HCIVirtualTransportAT.h
+++ b/src/utility/HCIVirtualTransportAT.h
@@ -39,4 +39,6 @@ public:
   virtual int read();
 
   virtual size_t write(const uint8_t* data, size_t length);
+
+  virtual void setLPMode(bool status);
 };


### PR DESCRIPTION
Adding the function `BLE.setLowPowerMode(bool)` to manage the lower power mode status of the BLE chip.

The function `BLE.setLowPowerMode(bool)`(`true`: to enable, `false`: to disable) must be called before executing the `BLE.begin()` function. Using this function after the BLE stack initialization will not have any effect.
The function does not directly control the entry and exit from low power mode but enables or disables the chip's feature.

Low power mode is enabled by default.

@sebromero Check it out if function name sounds good. Another proposal could be using two different functions: `enableLowPowerMode()` and `disableLowPowerMode()`.

This PR is based on the [arduino/mbed-os PR #32](https://github.com/arduino/mbed-os/pull/32).