### PR TITLE
Reset scan filters when stopScan is called [Fixes #350]

### DIFF
--- a/src/utility/GAP.cpp
+++ b/src/utility/GAP.cpp
@@ -137,6 +137,9 @@ void GAPClass::stopScan()
 {
   HCI.leSetScanEnable(false, false);
 
+  _scanNameFilter    = "";
+  _scanUuidFilter    = "";
+  _scanAddressFilter = "";
   _scanning = false;
 
   for (unsigned int i = 0; i < _discoveredDevices.size(); i++) {


### PR DESCRIPTION
This PR addresses a bug outlined in #350, where calling `stopScan` does not reset the filters set by `scanByName` etc, so a call to `scan` after will not work as expected.

Here's a barebones sketch that demonstrates the bug:

```cpp
#include <ArduinoBLE.h>

#define SERVICE_UUID "MY-SERVICE-UUID"

unsigned long scanStart;
bool fallbackToFullScan = false;

void setup() {
  Serial.begin(9600);
  delay(1000); // Wait for serial

  if (!BLE.begin()) {
    Serial.println("Starting BLE failed!");
    while (1);
  }

  Serial.println("Scanning by Service UUID...");
  BLE.scanForUuid(SERVICE_UUID);
  scanStart = millis();
}

void notWorkingScan() {
  BLE.stopScan();
  delay(1000);
  // This scan will not work - it will continue to behave like BLE.scanForUuid(SERVICE_UUID)
  BLE.scan();
}

void workingScan() {
  // This will reset _scanNameFilter, _scanUuidFilter, and _scanAddressFilter to ""
  BLE.scanForUuid("");
  BLE.stopScan();
  delay(1000);
  // This scan will now work
  BLE.scan();
}

void loop() {
  BLEDevice peripheral = BLE.available();

  if (peripheral) {
    Serial.println("Peripheral found!");
    BLE.stopScan();
  }

  // Wait 5 seconds to connect, then fall back to a regular scan.
  if (!fallbackToFullScan && millis() - scanStart > 5000) {
    scanStart = millis();
    Serial.println("Falling back to full scan...");
    fallbackToFullScan = true;
    // notWorkingScan();
    workingScan();
  }
}

```