### PR TITLE
Use mbed::callback for BLE event handler typedefs on ARDUINO_ARCH_MBED

### DIFF
--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -37,7 +37,12 @@ enum BLECharacteristicEvent {
 class BLECharacteristic;
 class BLEDevice;
 
+#ifdef ARDUINO_ARCH_MBED
+#include <mbed.h>
+typedef mbed::Callback<void (BLEDevice device, BLECharacteristic characteristic)> BLECharacteristicEventHandler;
+#else
 typedef void (*BLECharacteristicEventHandler)(BLEDevice device, BLECharacteristic characteristic);
+#endif
 
 class BLELocalCharacteristic;
 class BLERemoteCharacteristic;

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -34,7 +34,12 @@ enum BLEDeviceEvent {
 
 class BLEDevice;
 
+#ifdef ARDUINO_ARCH_MBED
+#include <mbed.h>
+typedef mbed::Callback<void (BLEDevice device)> BLEDeviceEventHandler;
+#else
 typedef void (*BLEDeviceEventHandler)(BLEDevice device);
+#endif
 
 class BLEDevice {
 public:


### PR DESCRIPTION
This allows using capturing lambdas for BLE device and characteristic event handlers on Mbed OS-based devices, as required by a recent project of mine:

```cpp
for (auto tup : senswarn_chars) {
  auto ble_char = std::get<BLEUnsignedCharCharacteristic*>(tup);
  auto val_ptr  = std::get<bool*>(tup);

  ble_char->setEventHandler(
      BLEWritten,
      [val_ptr](BLEDevice central, BLECharacteristic characteristic) {
        bool warning_active = *characteristic.value() != 0;

        if (*val_ptr != warning_active) { *val_ptr = warning_active; }

        if (warning_active) { ch_any_warning_active.writeValue(true); }
      });

  sv_senswarn.addCharacteristic(*ble_char);
}
```

Note: Perhaps a plain `std::function` type is permissible here in general. I no longer have access to the hardware to test this, unfortunately.