### PR TITLE
Add support for Silicon Labs board

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -24,6 +24,8 @@
 
 #include "BLECharacteristic.h"
 
+extern "C" int strcasecmp(char const *a, char const *b);
+
 BLECharacteristic::BLECharacteristic() :
   BLECharacteristic((BLELocalCharacteristic*)NULL)
 {

--- a/src/BLEDevice.cpp
+++ b/src/BLEDevice.cpp
@@ -25,6 +25,8 @@
 
 #include "BLEDevice.h"
 
+extern "C" int strcasecmp(char const *a, char const *b);
+
 BLEDevice::BLEDevice() :
   _advertisementTypeMask(0),
   _eirDataLength(0),

--- a/src/BLEService.cpp
+++ b/src/BLEService.cpp
@@ -22,6 +22,8 @@
 
 #include "BLEService.h"
 
+extern "C" int strcasecmp(char const *a, char const *b);
+
 BLEService::BLEService() :
   BLEService((BLELocalService*)NULL)
 {

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -34,6 +34,8 @@
 
 #include "ATT.h"
 
+extern "C" int strcasecmp(char const *a, char const *b);
+
 #define ATT_OP_ERROR              0x01
 #define ATT_OP_MTU_REQ            0x02
 #define ATT_OP_MTU_RESP           0x03

--- a/src/utility/HCISilabsTransport.cpp
+++ b/src/utility/HCISilabsTransport.cpp
@@ -1,0 +1,130 @@
+/*
+  This file is part of the ArduinoBLE library.
+  Copyright (c) 2024 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#if defined(ARDUINO_SILABS)
+
+#include "HCISilabsTransport.h"
+#include "sl_string.h"
+
+extern "C" {
+#include "sl_btctrl_linklayer.h"
+#include "sl_hci_common_transport.h"
+}
+
+extern "C" int strcasecmp(char const *a, char const *b) {
+  return sl_strcasecmp(a, b);
+}
+
+static RingBufferN<512> buf;
+
+HCISilabsTransportClass::HCISilabsTransportClass()
+{
+}
+
+HCISilabsTransportClass::~HCISilabsTransportClass()
+{
+}
+
+int HCISilabsTransportClass::begin()
+{
+  if(!sl_btctrl_is_initialized()) {
+    sl_bt_controller_init(); 
+  }
+
+  /* Initialize adv & scan components */
+  sl_btctrl_init_adv();
+  sl_btctrl_init_scan();
+  sl_btctrl_init_conn(); 
+  sl_btctrl_init_adv_ext();
+  sl_btctrl_init_scan_ext();
+
+  /* Initialize HCI controller */
+  sl_bthci_init_upper(); 
+  sl_btctrl_hci_parser_init_default();
+  sl_btctrl_hci_parser_init_conn();
+  sl_btctrl_hci_parser_init_adv();
+  sl_btctrl_hci_parser_init_phy();
+
+  return 1;
+}
+
+void HCISilabsTransportClass::end()
+{
+  sl_bt_controller_deinit();
+}
+
+void HCISilabsTransportClass::wait(unsigned long timeout)
+{
+  for (unsigned long start = millis(); (millis() - start) < timeout;) {
+    if (available()) {
+      break;
+    }
+  }
+}
+
+int HCISilabsTransportClass::available()
+{
+  return buf.available();
+}
+
+int HCISilabsTransportClass::peek()
+{
+  return buf.peek();
+}
+
+int HCISilabsTransportClass::read()
+{
+  return buf.read_char();
+}
+
+size_t HCISilabsTransportClass::write(const uint8_t* data, size_t len)
+{
+  int ret = 0;
+  ret = hci_common_transport_receive((uint8_t *)data, len, true);
+
+  if (ret == 0) return len;
+
+  return 0;
+}
+
+extern "C" {
+  /**
+   * @brief Transmit HCI message using the currently used transport layer.
+   * The HCI calls this function to transmit a full HCI message.
+   * @param[in] data Packet type followed by HCI packet data.
+   * @param[in] len Length of the `data` parameter
+   * @return 0 - on success, or non-zero on failure.
+   */
+  uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len)
+  {
+    for (int i = 0; i < len; i++) {
+      buf.store_char(data[i]);
+      if (buf.isFull()) return SL_STATUS_FAIL;
+    }
+    
+    sl_btctrl_hci_transmit_complete(0);
+    return 0;
+  }
+}
+
+HCISilabsTransportClass HCISilabsTransport;
+
+HCITransportInterface& HCITransport = HCISilabsTransport;
+
+#endif

--- a/src/utility/HCISilabsTransport.h
+++ b/src/utility/HCISilabsTransport.h
@@ -1,0 +1,42 @@
+/*
+  This file is part of the ArduinoBLE library.
+  Copyright (c) 2018 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _HCI_SILABS_TRANSPORT_H_
+#define _HCI_SILABS_TRANSPORT_H_
+
+#include "HCITransport.h"
+
+class HCISilabsTransportClass : public HCITransportInterface {
+public:
+  HCISilabsTransportClass();
+  virtual ~HCISilabsTransportClass();
+
+  virtual int begin();
+  virtual void end();
+
+  virtual void wait(unsigned long timeout);
+
+  virtual int available();
+  virtual int peek();
+  virtual int read();
+
+  virtual size_t write(const uint8_t* data, size_t length);
+};
+
+#endif

--- a/src/utility/HCIUartTransport.cpp
+++ b/src/utility/HCIUartTransport.cpp
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if !defined(ARDUINO_ARCH_MBED) && !defined(ESP32) && !defined(ARDUINO_UNOR4_WIFI) || defined(TARGET_NANO_RP2040_CONNECT) //|| defined(CORE_CM4)
+#if !defined(ARDUINO_ARCH_MBED) && !defined(ESP32) && !defined(ARDUINO_SILABS) && !defined(ARDUINO_UNOR4_WIFI) || defined(TARGET_NANO_RP2040_CONNECT) //|| defined(CORE_CM4)
 
 #include "HCIUartTransport.h"
 


### PR DESCRIPTION
This PR introduces compatibility for the ArduinoBLE library with Silicon Labs boards using the [Silicon Labs Arduino core](https://github.com/SiliconLabs/arduino).

It is not compatible with core version 2.0.0 but will be compatible in the next core release.