### PR TITLE
Arduino M0 board crashes when setting BLE handle from data buffer

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -993,8 +993,8 @@ void ATTClass::readOrReadBlobReq(uint16_t connectionHandle, uint16_t mtu, uint8_
   }
   /// if auth error, hold the response in a buffer.
   bool holdResponse = false;
-
-  uint16_t handle = *(uint16_t*)data;
+  uint16_t handle;
+  memcpy(&handle, data, sizeof(handle));
   uint16_t offset = (opcode == ATT_OP_READ_REQ) ? 0 : *(uint16_t*)&data[sizeof(handle)];
 
   if ((uint16_t)(handle - 1) > GATT.attributeCount()) {
@@ -1248,7 +1248,8 @@ void ATTClass::writeReqOrCmd(uint16_t connectionHandle, uint16_t mtu, uint8_t op
     return;
   }
 
-  uint16_t handle = *(uint16_t*)data;
+  uint16_t handle;
+  memcpy(&handle, data, sizeof(handle));
 
   if ((uint16_t)(handle - 1) > GATT.attributeCount()) {
     if (withResponse) {


### PR DESCRIPTION
This PR solves the issue of crashes and hangs on M0 board when assigning the variable `uint16_t handle` in the methods `ATTClass::readOrReadBlobReq` and `ATTClass::writeReqOrCmd` as reported also [here](https://github.com/arduino-libraries/ArduinoBLE/pull/316).

The problem was identified, also, trying to write a characteristic exposed by Arduino Nano RP2040 and Arduino MKR1010 from other Arduino boards.
