### PR TITLE
Clear advertising data when BLE end is called

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -224,7 +224,9 @@ void BLELocalDevice::end()
   digitalWrite(NINA_RESETN, LOW);
 #elif defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_GIGA) || defined(ARDUINO_OPTA)
   digitalWrite(BT_REG_ON, LOW);
-#endif
+#endif 
+  _advertisingData.clear();
+  _scanResponseData.clear();
 }
 
 void BLELocalDevice::poll()


### PR DESCRIPTION
The `_advertisingData` and `_scanResponseData` structure are never cleared even if the user call the `BLE.end()`. 
If the user after a BLE.end() opens again the BLE.begin() and confgure local name, service, characteristic, etc. some of them are not set properly since the counters and the data pointers are full from the previous iteration.

With this PR the clear method of `_advertisingData` and `_scanResponseData` is called inside the `BLE.end()` method.