### PR TITLE
Fix for BLE restart after a BLE end on portenta based devices

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -55,6 +55,7 @@
 #include "CordioHCICustomDriver.h"
 
 extern BLE_NAMESPACE::CordioHCIDriver& ble_cordio_get_hci_driver();
+extern "C" void hciTrSerialRxIncoming(uint8_t *pBuf, uint8_t len);
 
 namespace BLE_NAMESPACE {
   struct CordioHCIHook {
@@ -236,6 +237,13 @@ void HCICordioTransportClass::end()
     delete bleLoopThread;
     bleLoopThread = NULL;
   }
+  // Reset the callback with the mbed-os default handler to properly handle the following CYW43xxx chip initializations and begins
+  CordioHCIHook::setDataReceivedHandler(hciTrSerialRxIncoming);
+
+#if (defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION) || defined(ARDUINO_GIGA) || defined(ARDUINO_OPTA)) && !defined(CUSTOM_HCI_DRIVER)
+  BLE &ble = BLE::Instance();
+  ble.shutdown();
+#endif
 
 #if !defined(TARGET_STM32H7)
   CordioHCIHook::getDriver().terminate();


### PR DESCRIPTION
On portenta based board, if the user sketch starts and stops BLE several time, after the first time, the BLE stack advertises the wrong BLE mac address ( "AA:AA:AA:AA:AA:AA" ). This is caused because the BLE.end() function of ArduinoBLE doesn't turn off correctly the BLE mbed-os library.

Here a sketch for reproducing the bug.
```
#include <ArduinoBLE.h>
REDIRECT_STDOUT_TO(Serial);
BLEService ledService("19B10000-E8F2-537E-4F6C-D104768A1214"); // Bluetooth® Low Energy LED Service

// Bluetooth® Low Energy LED Switch Characteristic - custom 128-bit UUID, read and writable by central
BLEByteCharacteristic switchCharacteristic("19B10001-E8F2-537E-4F6C-D104768A1214", BLERead | BLEWrite);
bool turnedOn = false;
const int ledPin = LED_BUILTIN; // pin to use for the LED
uint32_t lastChange = 0;
void turnBLEon(){
 // begin initialization
  if (!BLE.begin()) {
    Serial.println("starting Bluetooth® Low Energy module failed!");

    while (1);
  }

  // set advertised local name and service UUID:
  BLE.setLocalName("LED");
  BLE.setAdvertisedService(ledService);

  // add the characteristic to the service
  ledService.addCharacteristic(switchCharacteristic);

  // add service
  BLE.addService(ledService);

  // set the initial value for the characeristic:
  switchCharacteristic.writeValue(0);

  // start advertising
  BLE.advertise();

  Serial.println("BLE LED Peripheral");
  turnedOn = true;
}

void turnBLEoff(){
  BLEDevice central = BLE.central();
  if(central && central.connected()){
    BLE.disconnect();
  }
  BLE.end();
  turnedOn=false;
}

void setup() {
  Serial.begin(9600);
  while (!Serial);
  //BLE.debug(Serial);
  // set LED pin to output mode
  pinMode(ledPin, OUTPUT);

  turnBLEon();
  lastChange = millis();
}

void loop() {

  if(lastChange + 20000 < millis()){
    if(turnedOn){
      Serial.println("change turn off");
      turnBLEoff();

    }else{
      Serial.println("change turn on");
      turnBLEon();
    }
    lastChange = millis();
  }

  if(turnedOn){
    // listen for Bluetooth® Low Energy peripherals to connect:
    BLEDevice central = BLE.central();

    // if a central is connected to peripheral:
    if (central) {
      Serial.print("Connected to central: ");
      // print the central's MAC address:
      Serial.println(central.address());

      // while the central is still connected to peripheral:
      while (central.connected()) {
        // if the remote device wrote to the characteristic,
        // use the value to control the LED:
        if (switchCharacteristic.written()) {
          if (switchCharacteristic.value()) {   // any value other than 0
            Serial.println("LED on");
            digitalWrite(ledPin, HIGH);         // will turn the LED on
          } else {                              // a 0 value
            Serial.println(F("LED off"));
            digitalWrite(ledPin, LOW);          // will turn the LED off
          }
        }
      }

      // when the central disconnects, print it out:
      Serial.print(F("Disconnected from central: "));
      Serial.println(central.address());
    }
  }
}
```
The fix improves the HCICordioTransportClass::end() calling the ble.shutdown() of mbed-os BLE library and restores the default HCI data received handler to make a valid initialization of the BLE chip at the coming restart.

This PR depends on [this PR ](https://github.com/arduino/mbed-os/pull/37)on the mbed-os repository; do not merge separately.
