### PR TITLE
Clear characteristic cccd value when disconnect

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -553,6 +553,22 @@ bool ATTClass::disconnect()
 
     numDisconnects++;
 
+    BLEDevice bleDevice(_peers[i].addressType, _peers[i].address);
+
+    // clear CCCD values on disconnect
+    for (uint16_t att = 0; att < GATT.attributeCount(); att++) {
+      BLELocalAttribute* attribute = GATT.attribute(att);
+
+      if (attribute->type() == BLETypeCharacteristic) {
+        BLELocalCharacteristic* characteristic = (BLELocalCharacteristic*)attribute;
+
+        characteristic->writeCccdValue(bleDevice, 0x0000);
+      }
+    }
+
+    _longWriteHandle = 0x0000;
+    _longWriteValueLength = 0;
+
     _peers[i].connectionHandle = 0xffff;
     _peers[i].role = 0x00;
     _peers[i].addressType = 0x00;


### PR DESCRIPTION
### Problem
If the peripheral sketch with a subscribeable characteristic closes the connection with the central calling the `BLE.disconnect()` all subsequent subscriptions, after the first connection, are not notified and the characteristic stays always as "subscribed".

### Solution
In this PR the characteristic CCCD value is cleared when the BLE.disconnect() is called for resetting the characteristic subscription status and allowing new subscriptions.
 
### Sketches for reproducing the problem
**Central**
```c++
#include <ArduinoBLE.h>
void setup() {
  Serial.begin(9600);
  while (!Serial);

  // initialize the Bluetooth® Low Energy hardware
  BLE.begin();
 BLE.scanForUuid("19B10000-E8F2-537E-4F6C-D104768A1214");
}

void loop() {
  // put your main code here, to run repeatedly:
BLEDevice peripheral = BLE.available();

  if (peripheral) {
    // discovered a peripheral, print out address, local name, and advertised service
    Serial.print("Found ");
    Serial.print(peripheral.address());
    Serial.print(" '");
    Serial.print(peripheral.localName());
    Serial.print("' ");
    Serial.print(peripheral.advertisedServiceUuid());
    Serial.println();


    // stop scanning
    BLE.stopScan();

    controlLed(peripheral);
    delay(10000);
    // peripheral disconnected, start scanning again
    BLE.scanForUuid("19b10000-e8f2-537e-4f6c-d104768a1214");
  }
}

void controlLed(BLEDevice peripheral) {
  // connect to the peripheral
  Serial.println("Connecting ...");

  if (peripheral.connect()) {
    Serial.println("Connected");
  } else {
    Serial.println("Failed to connect!");
    return;
  }

  // discover peripheral attributes
  Serial.println("Discovering attributes ...");
  if (peripheral.discoverAttributes()) {
    Serial.println("Attributes discovered");
  } else {
    Serial.println("Attribute discovery failed!");
    peripheral.disconnect();
    return;
  }

  BLECharacteristic byteCharacteristic = peripheral.characteristic("19B10001-E8F2-537E-4F6C-D104768A1214");
  if (!byteCharacteristic) {
    Serial.println("Peripheral does not have LED characteristic!");
    peripheral.disconnect();
    return;
  } else if (!byteCharacteristic.canSubscribe()) {
    Serial.println("Peripheral does not have a writable LED characteristic!");
    peripheral.disconnect();
    return;
  } else if (!byteCharacteristic.subscribe()) {
    Serial.println("subscription failed!");
    peripheral.disconnect();
    return;
  } else {
    Serial.println("Subscribed");
  }
  while (peripheral.connected()) {
    // while the peripheral is connected

    // check if the value of the simple key characteristic has been updated
    if (byteCharacteristic.valueUpdated()) {
      // yes, get the value, characteristic is 1 byte so use byte value
      byte value = 0;
      
      byteCharacteristic.readValue(value);

      Serial.print("received: ");
      Serial.println(value, HEX);
 
    }
  }
  Serial.println("Disconnected");
  
}

```
**Peripheral**
```c++
#include <ArduinoBLE.h>
BLEService testService("19B10000-E8F2-537E-4F6C-D104768A1214");
BLEByteCharacteristic byteCharacteristic("19B10001-E8F2-537E-4F6C-D104768A1214", BLERead | BLEIndicate | BLEWrite);
volatile bool disconnect = false;
void byteRead(BLEDevice central, BLECharacteristic characteristic){
  Serial.println("Characteristic subscribed, sending data");
  byte c = 0x01; 
  int written = byteCharacteristic.writeValue(c);
  disconnect=true;
}
void setup() {
    Serial.begin(9600);
  while (!Serial);
  // put your setup code here, to run once:
  if (!BLE.begin()) {
    Serial.println("starting Bluetooth® Low Energy module failed!");

    while (1);
  }

  // set advertised local name and service UUID:
  if(!BLE.setLocalName("TEST-LOCAL-NAME")){
    Serial.println("error setting the local name");
  }

  byteCharacteristic.setEventHandler(BLESubscribed, byteRead);
  BLE.setAdvertisedService(testService);

   // add the characteristic to the service
  testService.addCharacteristic(byteCharacteristic);

   // add service
  BLE.addService(testService);

  // start advertising
  BLE.advertise();

  Serial.println("BLE Peripheral");

}

void loop() {
  // put your main code here, to run repeatedly:
  if(disconnect){
    BLE.disconnect();
    disconnect = false;
    Serial.println("disconnected");
  }
 BLE.poll();
 
}
```

### Logs
Here the logs of the current behaviour.
**Central**
```
11:18:48.793 -> Found 34:94:54:27:05:66 'TEST-LOCAL-NAME' 19b10000-e8f2-537e-4f6c-d104768a1214
11:18:48.829 -> Connecting ...
11:18:48.897 -> Connected
11:18:48.897 -> Discovering attributes ...
11:18:49.291 -> Attributes discovered
11:18:49.330 -> Subscribed
11:18:49.330 -> received: 1
11:18:49.330 -> Disconnected
//End of the first run
11:18:59.416 -> Found 34:94:54:27:05:66 'TEST-LOCAL-NAME' 19b10000-e8f2-537e-4f6c-d104768a1214
11:18:59.448 -> Connecting ...
11:18:59.527 -> Connected
11:18:59.527 -> Discovering attributes ...
11:18:59.948 -> Attributes discovered
11:18:59.948 -> Subscribed
//Has never received new data since the peripheral never sends it
```
**Peripheral**
```
11:18:27.926 -> BLE Peripheral
11:18:49.291 -> Characteristic subscribed, sending data
11:18:49.330 -> disconnected
// Note that the subscribed event at 11:18:59.948 has never been notified to the sketch
```



