### PR TITLE
Add BLEPermission Support to BLEStringCharacteristic

### DIFF
--- a/src/BLEStringCharacteristic.cpp
+++ b/src/BLEStringCharacteristic.cpp
@@ -19,7 +19,7 @@
 
 #include "BLEStringCharacteristic.h"
 
-BLEStringCharacteristic::BLEStringCharacteristic(const char* uuid, unsigned char properties, int valueSize) :
+BLEStringCharacteristic::BLEStringCharacteristic(const char* uuid, unsigned int properties, int valueSize) :
   BLECharacteristic(uuid, properties, valueSize)
 {
 }

--- a/src/BLEStringCharacteristic.h
+++ b/src/BLEStringCharacteristic.h
@@ -27,7 +27,7 @@
 class BLEStringCharacteristic : public BLECharacteristic
 {
 public:
-  BLEStringCharacteristic(const char* uuid, unsigned char properties, int valueSize);
+  BLEStringCharacteristic(const char* uuid, unsigned int properties, int valueSize);
 
   int writeValue(const String& value);
   int setValue(const String& value) { return writeValue(value); }


### PR DESCRIPTION
5 years ago, support for encryption was added by #156. Currently, the BLEEncryption tag needs to be added to require proper encrypted bluetooth pairing. It is possible to add this tag to all other kinds of characteristics except String characteristics.

BLEStringCharacteristic's constructor calls BLECharacteristic's constructor, and BLECharacteristic uses a uint16_t instead of a uint8_t.

This PR simply changes the properties attribute of BLEStringCharacteristic to match the width of the permissions attribute of BLECharacteristic (from 8 to 16 bits) to support the BLEPermission tags in BLEProperty.h.