### PR TITLE
fix: compilation error when using _BLE_TRACE

### DIFF
--- a/src/utility/L2CAPSignaling.cpp
+++ b/src/utility/L2CAPSignaling.cpp
@@ -230,9 +230,9 @@ void L2CAPSignalingClass::handleSecurityData(uint16_t connectionHandle, uint8_t 
     Serial.print("V      : ");
     btct.printBytes(V,32);
     Serial.print("X      : ");
-    btct.printBytes(X,16);
+    btct.printBytes(HCI.Na,16);
     Serial.print("Y      : ");
-    btct.printBytes(Y,16);
+    btct.printBytes(HCI.Nb,16);
     Serial.print("g2res  : ");
     btct.printBytes(g2Result,4);
     Serial.print("Result : ");
@@ -413,7 +413,7 @@ void L2CAPSignalingClass::smCalculateLTKandConfirm(uint16_t handle, uint8_t expe
     // Send our confirmation value to complete authentication stage 2
     uint8_t ret[17];
     ret[0] = CONNECTION_PAIRING_DHKEY_CHECK;
-    for(int i=0; i<sizeof(Eb); i++){
+    for(uint i=0; i<sizeof(Eb); i++){
       ret[sizeof(Eb)-i] = Eb[i];
     }
     HCI.sendAclPkt(handle, SECURITY_CID, sizeof(ret), ret );

--- a/src/utility/L2CAPSignaling.cpp
+++ b/src/utility/L2CAPSignaling.cpp
@@ -413,7 +413,7 @@ void L2CAPSignalingClass::smCalculateLTKandConfirm(uint16_t handle, uint8_t expe
     // Send our confirmation value to complete authentication stage 2
     uint8_t ret[17];
     ret[0] = CONNECTION_PAIRING_DHKEY_CHECK;
-    for(uint i=0; i<sizeof(Eb); i++){
+    for(uint32_t i=0; i<sizeof(Eb); i++){
       ret[sizeof(Eb)-i] = Eb[i];
     }
     HCI.sendAclPkt(handle, SECURITY_CID, sizeof(ret), ret );


### PR DESCRIPTION
Now correctly acceses the existing variables and uses an unsigned int for size comparison

fixes #355