### PR TITLE
fix: signed and init field warnings

### DIFF
--- a/src/utility/HCI.cpp
+++ b/src/utility/HCI.cpp
@@ -138,7 +138,7 @@ void HCIClass::poll(unsigned long timeout)
   while (HCITransport.available()) {
     byte b = HCITransport.read();
 
-    if (_recvIndex >= sizeof(_recvBuffer)) {
+    if (_recvIndex >= (int)sizeof(_recvBuffer)) {
         _recvIndex = 0;
         if (_debug) {
             _debug->println("_recvBuffer overflow");
@@ -461,6 +461,8 @@ int HCIClass::leConnUpdate(uint16_t handle, uint16_t minInterval, uint16_t maxIn
   return sendCommand(OGF_LE_CTL << 10 | OCF_LE_CONN_UPDATE, sizeof(leConnUpdateData), &leConnUpdateData);
 }
 void HCIClass::saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* localIrk){
+  (void)addressType;
+  (void)localIrk;
   if(_storeIRK!=0){
     _storeIRK(address, peerIrk);
   }
@@ -503,6 +505,7 @@ int HCIClass::leStartResolvingAddresses(){
   return HCI.sendCommand(OGF_LE_CTL << 10 | 0x2D, 1,&enable); // Disable address resolution
 }
 int HCIClass::leReadPeerResolvableAddress(uint8_t peerAddressType, uint8_t* peerIdentityAddress, uint8_t* peerResolvableAddress){
+  (void)peerResolvableAddress;
   struct __attribute__ ((packed)) Request {
     uint8_t addressType;
     uint8_t identityAddress[6];
@@ -546,7 +549,7 @@ int HCIClass::readStoredLK(uint8_t BD_ADDR[], uint8_t read_all ){
   struct __attribute__ ((packed)) Request {
     uint8_t BD_ADDR[6];
     uint8_t read_a;
-  } request = {0,0};
+  } request = {{0},0};
   for(int i=0; i<6; i++) request.BD_ADDR[5-i] = BD_ADDR[i];
   request.read_a = read_all;
   return sendCommand(OGF_HOST_CTL << 10 | 0xD, sizeof(request), &request);
@@ -1268,7 +1271,7 @@ void HCIClass::handleEventPkt(uint8_t /*plen*/, uint8_t pdata[])
             uint8_t U[32];
             uint8_t V[32];
             uint8_t Z;
-          } f4Params = {0,0,Z};
+          } f4Params = {{0},{0},Z};
           for(int i=0; i<32; i++){
             f4Params.U[31-i] = pairingPublicKey.publicKey[i];
             f4Params.V[31-i] = HCI.remotePublicKeyBuffer[i];
@@ -1288,7 +1291,7 @@ void HCIClass::handleEventPkt(uint8_t /*plen*/, uint8_t pdata[])
 #endif
 
           uint8_t cb_temp[sizeof(pairingConfirm.cb)];
-          for(int i=0; i<sizeof(pairingConfirm.cb);i++){
+          for(unsigned int i=0; i<sizeof(pairingConfirm.cb);i++){
             cb_temp[sizeof(pairingConfirm.cb)-1-i] = pairingConfirm.cb[i];
           }
           /// cb wa back to front.
@@ -1372,11 +1375,12 @@ void HCIClass::handleEventPkt(uint8_t /*plen*/, uint8_t pdata[])
   }
 }
 int HCIClass::leEncrypt(uint8_t* key, uint8_t* plaintext, uint8_t* status, uint8_t* ciphertext){
+  (void)status;
   struct __attribute__ ((packed)) LeEncryptCommand
   {
     uint8_t key[16];
     uint8_t plaintext[16];
-  } leEncryptCommand = {0,0};
+  } leEncryptCommand = {{0},{0}};
   for(int i=0; i<16; i++){
     leEncryptCommand.key[15-i] = key[i];
     leEncryptCommand.plaintext[15-i] = plaintext[i];

--- a/src/utility/L2CAPSignaling.cpp
+++ b/src/utility/L2CAPSignaling.cpp
@@ -122,6 +122,8 @@ void L2CAPSignalingClass::handleSecurityData(uint16_t connectionHandle, uint8_t 
 #ifdef _BLE_TRACE_
   Serial.print("dlen: ");
   Serial.println(dlen);
+#else
+  (void)dlen;
 #endif
   uint8_t code = l2capSignalingHdr->code;
 
@@ -310,8 +312,8 @@ void L2CAPSignalingClass::handleSecurityData(uint16_t connectionHandle, uint8_t 
       uint8_t x[32];
       uint8_t y[32];
     } generateDHKeyCommand = {
-      0x00,
-      0x00,
+      {0x00},
+      {0x00},
     };
     memcpy(generateDHKeyCommand.x,connectionPairingPublicKey->x,32);
     memcpy(generateDHKeyCommand.y,connectionPairingPublicKey->y,32);

--- a/src/utility/btct.cpp
+++ b/src/utility/btct.cpp
@@ -71,7 +71,7 @@ int BluetoothCryptoToolbox::f5(uint8_t DHKey[],uint8_t N_master[], uint8_t N_sla
         uint8_t A1[7];
         uint8_t A2[7];
         uint8_t length[2];
-    } cmacInput = {0,0,0,0,0,0,0};
+    } cmacInput = {0,{0},{0},{0},{0},{0},{0}};
     cmacInput.counter = 0;
     memcpy(cmacInput.keyID, keyID, 4);
     memcpy(cmacInput.N1,N_master,16);
@@ -97,7 +97,7 @@ int BluetoothCryptoToolbox::f6(uint8_t W[], uint8_t N1[],uint8_t N2[],uint8_t R[
         uint8_t IOCap[3];
         uint8_t A1[7];
         uint8_t A2[7];
-    } f6Input = {0,0,0,0,0,0};
+    } f6Input = {{0},{0},{0},{0},{0},{0}};
 
     memcpy(f6Input.N1, N1, 16);
     memcpy(f6Input.N2, N2, 16);
@@ -145,7 +145,7 @@ int BluetoothCryptoToolbox::g2(uint8_t U[], uint8_t V[], uint8_t X[], uint8_t Y[
         uint8_t U[32];
         uint8_t V[32];
         uint8_t Y[16];
-    } cmacInput= {0,0,0};
+    } cmacInput= {{0},{0},{0}};
     memcpy(cmacInput.U,U,32);
     memcpy(cmacInput.V,V,32);
     memcpy(cmacInput.Y,Y,16);


### PR DESCRIPTION
```log
src/utility/L2CAPSignaling.cpp: In member function 'virtual void L2CAPSignalingClass::handleSecurityData(uint16_t, uint8_t, uint8_t*)':
src/utility/L2CAPSignaling.cpp:315:5: warning: missing initializer for member 'L2CAPSignalingClass::handleSecurityData(uint16_t, uint8_t, uint8_t*)::GenerateDHKeyCommand::y' [-Wmissing-field-initializers]
  315 |     };
      |     ^
src/utility/L2CAPSignaling.cpp:116:81: warning: unused parameter 'dlen' [-Wunused-parameter]
  116 | void L2CAPSignalingClass::handleSecurityData(uint16_t connectionHandle, uint8_t dlen, uint8_t data[])
      |                                                                         ~~~~~~~~^~~~
src/utility/L2CAPSignaling.cpp: In member function 'virtual void L2CAPSignalingClass::smCalculateLTKandConfirm(uint16_t, uint8_t*)':
src/utility/L2CAPSignaling.cpp:418:19: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  418 |     for(int i=0; i<sizeof(Eb); i++){
      |                  ~^~~~~~~~~~~
src/utility/HCI.cpp: In member function 'virtual void HCIClass::poll(long unsigned int)':
src/utility/HCI.cpp:142:20: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  142 |     if (_recvIndex >= sizeof(_recvBuffer)) {
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
src/utility/HCI.cpp: In member function 'virtual void HCIClass::saveNewAddress(uint8_t, uint8_t*, uint8_t*, uint8_t*)':
src/utility/HCI.cpp:464:39: warning: unused parameter 'addressType' [-Wunused-parameter]
  464 | void HCIClass::saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* localIrk){
      |                               ~~~~~~~~^~~~~~~~~~~
src/utility/HCI.cpp:464:97: warning: unused parameter 'localIrk' [-Wunused-parameter]
  464 | void HCIClass::saveNewAddress(uint8_t addressType, uint8_t* address, uint8_t* peerIrk, uint8_t* localIrk){
      |                                                                                        ~~~~~~~~~^~~~~~~~
src/utility/HCI.cpp: In member function 'virtual int HCIClass::leReadPeerResolvableAddress(uint8_t, uint8_t*, uint8_t*)':
src/utility/HCI.cpp:506:107: warning: unused parameter 'peerResolvableAddress' [-Wunused-parameter]
  506 | int HCIClass::leReadPeerResolvableAddress(uint8_t peerAddressType, uint8_t* peerIdentityAddress, uint8_t* peerResolvableAddress){
      |                                                                                                  ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
src/utility/HCI.cpp: In member function 'virtual int HCIClass::readStoredLK(uint8_t*, uint8_t)':
src/utility/HCI.cpp:550:19: warning: missing initializer for member 'HCIClass::readStoredLK(uint8_t*, uint8_t)::Request::read_a' [-Wmissing-field-initializers]
  550 |   } request = {0,0};
      |                   ^
src/utility/HCI.cpp: In member function 'virtual void HCIClass::handleEventPkt(uint8_t, uint8_t*)':
src/utility/HCI.cpp:1275:30: warning: missing initializer for member 'HCIClass::handleEventPkt(uint8_t, uint8_t*)::F4Params::V' [-Wmissing-field-initializers]
 1275 |           } f4Params = {0,0,Z};
      |                              ^
src/utility/HCI.cpp:1275:30: warning: missing initializer for member 'HCIClass::handleEventPkt(uint8_t, uint8_t*)::F4Params::Z' [-Wmissing-field-initializers]
src/utility/HCI.cpp:1295:25: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
 1295 |           for(int i=0; i<sizeof(pairingConfirm.cb);i++){
      |                        ~^~~~~~~~~~~~~~~~~~~~~~~~~~
src/utility/HCI.cpp: In member function 'virtual int HCIClass::leEncrypt(uint8_t*, uint8_t*, uint8_t*, uint8_t*)':
src/utility/HCI.cpp:1383:28: warning: missing initializer for member 'HCIClass::leEncrypt(uint8_t*, uint8_t*, uint8_t*, uint8_t*)::LeEncryptCommand::plaintext' [-Wmissing-field-initializers]
 1383 |   } leEncryptCommand = {0,0};
      |                            ^
src/utility/HCI.cpp:1378:68: warning: unused parameter 'status' [-Wunused-parameter]
 1378 | int HCIClass::leEncrypt(uint8_t* key, uint8_t* plaintext, uint8_t* status, uint8_t* ciphertext){
      |                                                           ~~~~~~~~~^~~~~~
src/utility/btct.cpp: In member function 'int BluetoothCryptoToolbox::f5(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)':
src/utility/btct.cpp:74:33: warning: missing initializer for member 'BluetoothCryptoToolbox::f5(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::N2' [-Wmissing-field-initializers]
   74 |     } cmacInput = {0,0,0,0,0,0,0};
      |                                 ^
src/utility/btct.cpp:74:33: warning: missing initializer for member 'BluetoothCryptoToolbox::f5(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::A1' [-Wmissing-field-initializers]
src/utility/btct.cpp:74:33: warning: missing initializer for member 'BluetoothCryptoToolbox::f5(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::A2' [-Wmissing-field-initializers]
src/utility/btct.cpp:74:33: warning: missing initializer for member 'BluetoothCryptoToolbox::f5(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::length' [-Wmissing-field-initializers]
src/utility/btct.cpp: In member function 'int BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)':
src/utility/btct.cpp:100:29: warning: missing initializer for member 'BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::F6Input::N2' [-Wmissing-field-initializers]
  100 |     } f6Input = {0,0,0,0,0,0};
      |                             ^
src/utility/btct.cpp:100:29: warning: missing initializer for member 'BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::F6Input::R' [-Wmissing-field-initializers]
src/utility/btct.cpp:100:29: warning: missing initializer for member 'BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::F6Input::IOCap' [-Wmissing-field-initializers]
src/utility/btct.cpp:100:29: warning: missing initializer for member 'BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::F6Input::A1' [-Wmissing-field-initializers]
src/utility/btct.cpp:100:29: warning: missing initializer for member 'BluetoothCryptoToolbox::f6(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::F6Input::A2' [-Wmissing-field-initializers]
src/utility/btct.cpp: In member function 'int BluetoothCryptoToolbox::g2(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)':
src/utility/btct.cpp:148:24: warning: missing initializer for member 'BluetoothCryptoToolbox::g2(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::V' [-Wmissing-field-initializers]
  148 |     } cmacInput= {0,0,0};
      |                        ^
src/utility/btct.cpp:148:24: warning: missing initializer for member 'BluetoothCryptoToolbox::g2(uint8_t*, uint8_t*, uint8_t*, uint8_t*, uint8_t*)::CmacInput::Y' [-Wmissing-field-initializers]
```