### PR TITLE
Use CEspChipManager for chip initialization on Portenta C33

### DIFF
--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -34,6 +34,10 @@
 #undef ARDUINO_UNO_Q
 #endif
 
+#if defined(ARDUINO_PORTENTA_C33)
+#include <EspChipManager.h>
+#endif
+
 #if defined(PORTENTA_H7_PINS) || defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_OPTA)
 #ifndef BT_REG_ON
 #define BT_REG_ON PJ_12
@@ -86,17 +90,9 @@ int BLELocalDevice::begin()
   digitalWrite(BT_REG_ON, HIGH);
   delay(500);
 #elif defined(ARDUINO_PORTENTA_C33)
-#define NINA_GPIO0      (100)
-#define NINA_RESETN     (101)
-  pinMode(NINA_GPIO0, OUTPUT);
-  pinMode(NINA_RESETN, OUTPUT);
-  Serial5.begin(921600);
 
-  digitalWrite(NINA_GPIO0, HIGH);
-  delay(100);
-  digitalWrite(NINA_RESETN, HIGH);
-  digitalWrite(NINA_RESETN, LOW);
-  digitalWrite(NINA_RESETN, HIGH);
+  Serial5.begin(921600);
+  CEspChipManager::getInstance().initialize();
   auto _start = millis();
   while (millis() - _start < 500) {
     if (Serial5.available()) {


### PR DESCRIPTION
### Description:
This PR solves the issue that prevents the use of the BLE and the WiFi connectivities at the same time. The issue is that if the sketch initializes the BLE first and then inizializes the WiFi, the BLE stops working.

### Changes:

- use the `CEspChipManager` for chip initialization

This PR relies on https://github.com/arduino/ArduinoCore-renesas/pull/472