### PR TITLE
Rewrite handleAclDataPkt to correctly handle fragments

### DIFF
--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -159,7 +159,8 @@ private:
   uint8_t _maxPkt;
   uint8_t _pendingPkt;
 
-  uint8_t _aclPktBuffer[255];
+  uint8_t _l2CapPduBuffer[255];
+  uint8_t _l2CapPduBufferSize;
 };
 
 extern HCIClass& HCI;


### PR DESCRIPTION
I've noticed that sometimes my BLE connection is interrupted because of a "Rejecting packet cid" error when I send many fragmented packets. I suspect this issue to be caused by the following line:

https://github.com/arduino-libraries/ArduinoBLE/blob/9263b3a058d5b00fe47b2ed244bbaa98853d3214/src/utility/HCI.cpp#L730

I don't think a fragment has a L2CAP header. Therefore, the `len` field points to arbitrary data. Sometimes it matches the the value in the condition and the packet is misinterpreted (and causes the CID error).

This MR rewrites the `handleAclDataPkt` method to be more readable and produce more user-friendly debug output.