### PR TITLE
Use locks to prevent race conditions in HCICordioTransport

### DIFF
--- a/src/utility/HCICordioTransport.h
+++ b/src/utility/HCICordioTransport.h
@@ -40,6 +40,9 @@ public:
   virtual int peek();
   virtual int read();
 
+  virtual void lockForRead() override;
+  virtual void unlockForRead() override;
+
   virtual size_t write(const uint8_t* data, size_t length);
 
 private:

--- a/src/utility/HCITransport.h
+++ b/src/utility/HCITransport.h
@@ -33,6 +33,12 @@ public:
   virtual int peek() = 0;
   virtual int read() = 0;
 
+  // Some transports require a lock to use available/peek/read
+  // These methods allow to keep the lock while reading an unknown number of bytes
+  // These methods might disable interrupts. Only keep the lock as long as necessary.
+  virtual void lockForRead() {}
+  virtual void unlockForRead() {}
+
   virtual size_t write(const uint8_t* data, size_t length) = 0;
 };
 


### PR DESCRIPTION
Sometimes my BLE connections to my nrf52840 randomly stopped working. I've noticed that with `BLE.debug(Serial)` the HCI transport returned truncated packets in these situations. I suspect that this issue might be caused by concurrent access to the rx buffer in the cordio HCI transport. The Arduino core seems to use critical section locks [while interacting with the ring buffers](https://github.com/arduino/ArduinoCore-mbed/blob/1302d80a4c1e770460132c76a280388bf44fe153/cores/arduino/Serial.cpp#L176-L178).

This MR introduces a `lockForRead` and `unlockForRead` method on the HCITransport to aquire a critical section lock. A Mutex might make more sense, but requires additional build flags and might not be available if `handleRxData` is called from an interrupt handler.

I've considered the following alternatives to the new methods:
- Just lock/unlock during `read()`. This naive approach works, but is very inefficient.
- Introduce a `readBytes()` method similar to Arduino's stream method which handles the lock/unlock. This approach is more difficult to implement because you don't know beforehand how large a packet is. You will still need multiple calls to `readBytes()` (including unnecessary lock/unlock calls).