### PR TITLE
Enter critical section only for Arduino Nano 33 BLE

### DIFF
--- a/src/utility/HCICordioTransport.cpp
+++ b/src/utility/HCICordioTransport.cpp
@@ -311,7 +311,9 @@ size_t HCICordioTransportClass::write(const uint8_t* data, size_t length)
 void HCICordioTransportClass::handleRxData(uint8_t* data, uint8_t len)
 {
   {
+    #if defined(ARDUINO_ARCH_NRF52840)
     mbed::CriticalSectionLock critical_section;
+    #endif
     if (_rxBuf.availableForStore() < len) {
       // drop!
       return;
@@ -321,7 +323,6 @@ void HCICordioTransportClass::handleRxData(uint8_t* data, uint8_t len)
       _rxBuf.store_char(data[i]);
     }
   }
-
   bleEventFlags.set(0x01);
 }
 


### PR DESCRIPTION
The PR https://github.com/arduino-libraries/ArduinoBLE/pull/402 introduces crashes on the Opta device if using BLE and Ethernet together. 
This is due to the `mbed::CriticalSectionLock critical_section;` RAII mechanism inside the `HCICordioTransportClass::handleRxData` function. This function on Opta and Portenta H7 is executed within an ISR context, so the critical section statement is not needed and can cause crashes if used with the Ethernet enabled. 

This PR addresses the problem by entering the critical section only for the Nano 33 BLE or Nano 33 BLE Sense boards.

