### PR TITLE
HCIVirtualTransportRPC: explicitly use HCI object from ArduinoBridge

### DIFF
--- a/src/utility/HCIVirtualTransportRPC.cpp
+++ b/src/utility/HCIVirtualTransportRPC.cpp
@@ -21,6 +21,10 @@
 
 #include "HCIVirtualTransportRPC.h"
 
+#include <Arduino_RouterBridge.h>
+
+using RouterBridge::HCI;
+
 HCIVirtualTransportRPCClass::HCIVirtualTransportRPCClass() : initialized(false) {
 }
 

--- a/src/utility/HCIVirtualTransportRPC.h
+++ b/src/utility/HCIVirtualTransportRPC.h
@@ -22,7 +22,6 @@
 
 #include "HCITransport.h"
 #include "api/RingBuffer.h"
-#include <Arduino_RouterBridge.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This change hides some of the implementation details from the upper levels, by only imcluding `<Arduino_RouterBridge.h>` in the source file.

The HCI object is also explicitly scoped to avoid clashes with the public HCI object exposed by this library.