### PR TITLE
Fix ATT descriptor discovery handle range and response parsing

### DIFF
--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -1735,7 +1735,7 @@ bool ATTClass::discoverDescriptors(uint16_t connectionHandle, BLERemoteDevice* d
       BLERemoteCharacteristic* nextCharacteristic = (j == (characteristicCount - 1)) ? NULL : service->characteristic(j + 1);
 
       reqStartHandle = characteristic->valueHandle() + 1;
-      reqEndHandle = nextCharacteristic ? nextCharacteristic->valueHandle() : serviceEndHandle;
+      reqEndHandle = nextCharacteristic ? nextCharacteristic->startHandle() - 1 : serviceEndHandle;
 
       if (reqStartHandle > reqEndHandle) {
         continue;
@@ -1749,8 +1749,14 @@ bool ATTClass::discoverDescriptors(uint16_t connectionHandle, BLERemoteDevice* d
         }
 
         if (responseBuffer[0] == ATT_OP_FIND_INFO_RESP) {
-          uint16_t lengthPerDescriptor = responseBuffer[1] * 4;
-          uint8_t uuidLen = 2;
+          uint8_t format = responseBuffer[1];
+
+          if (format != 0x01 && format != 0x02) {
+            return false;
+          }
+
+          uint16_t lengthPerDescriptor = (format == 0x01) ? 4 : 18;
+          uint8_t uuidLen = (format == 0x01) ? 2 : 16;
 
           for (int i = 2; i < respLength; i += lengthPerDescriptor) {
             struct __attribute__ ((packed)) RawDescriptor {


### PR DESCRIPTION
## Problem

`ATTClass::discoverDescriptors()` currently has two issues.

First, the descriptor discovery range ends at the value handle of the next characteristic. This includes the next characteristic declaration and value in the descriptor range of the current characteristic.

Second, byte 1 of an ATT Find Information Response is a Format field, not a length multiplier. Format `0x01` contains 4-byte entries (2-byte handle + 2-byte UUID), while format `0x02` contains 18-byte entries (2-byte handle + 16-byte UUID).

The current implementation calculates an 8-byte entry length for format `0x02` and always parses UUIDs as 16-bit.

This can cause `discoverAttributes()` to fail or time out when a service contains multiple 128-bit characteristics.

Related to #277.

## Changes

- End descriptor discovery immediately before the next characteristic declaration.
- Parse both ATT Find Information Response formats correctly.
- Reject unsupported response format values.

## Hardware test

Tested using two Arduino Nano 33 BLE boards, one configured as central and the other as peripheral, with ArduinoBLE 1.5.0.

The peripheral exposes a 128-bit service containing multiple 128-bit characteristics, including a notify characteristic with a CCCD.

Before the change:

- The BLE connection succeeds.
- `discoverAttributes()` does not complete.
- The central reports HCI receive-buffer overflows.
- The connection eventually terminates.

After the change:

- Attribute discovery completes successfully.
- The expected characteristics are found.
- CCCD subscription succeeds.
- The central receives 16-byte notifications correctly.